### PR TITLE
Add a redirection switch for download and details view when no view given

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Redirect users without any modifying permissions (without editable border)
+  to the download when not hitting a specific view.
+  Also add File back to allowAnonymousViewAbout for making sure that /view
+  is added in the navigation.
+  [jone]
 
 
 1.6.4 (2013-06-04)

--- a/ftw/file/__init__.py
+++ b/ftw/file/__init__.py
@@ -1,7 +1,7 @@
 """Main product initializer
 """
 from Products.Archetypes import atapi
-from Products.CMFCore import utils
+from Products.CMFCore.utils import ContentInit
 from ftw.file import config
 from zope.i18nmessageid import MessageFactory
 
@@ -18,7 +18,7 @@ def initialize(context):
 
     # Now initialize all these content types.
     for atype, constructor in zip(content_types, constructors):
-        utils.ContentInit('%s: %s' % (config.PROJECTNAME, atype.portal_type),
+        ContentInit('%s: %s' % (config.PROJECTNAME, atype.portal_type),
             content_types=(atype, ),
             permission=config.ADD_PERMISSIONS[atype.portal_type],
             extra_constructors=(constructor, ),

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -1,20 +1,21 @@
 from AccessControl import ClassSecurityInfo
-from ftw.file import fileMessageFactory as _
-from ftw.file.config import PROJECTNAME
-from ftw.file.fields import FileField
-from ftw.file.interfaces import IFile
-from ftw.journal.interfaces import IWorkflowHistoryJournalizable
-from logging import getLogger
-from plone.app.blob.field import BlobMarshaller
-from Products.Archetypes import atapi
+from DateTime import DateTime
 from Products.ATContentTypes.content.file import ATFile, ATFileSchema
+from Products.Archetypes import atapi
 from Products.CMFCore.permissions import  View, ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
 from Products.validation import V_REQUIRED
 from ZODB.POSException import ConflictError
-from zope.interface import implements
 from ftw.calendarwidget.browser.widgets import FtwCalendarWidget
-from DateTime import DateTime
+from ftw.file import fileMessageFactory as _
+from ftw.file.config import PROJECTNAME
+from ftw.file.fields import FileField
+from ftw.file.interfaces import IFile
+from ftw.file.utils import redirect_to_download_by_default
+from ftw.journal.interfaces import IWorkflowHistoryJournalizable
+from logging import getLogger
+from plone.app.blob.field import BlobMarshaller
+from zope.interface import implements
 
 FileSchema = ATFileSchema.copy() + atapi.Schema((
     FileField(
@@ -70,8 +71,12 @@ class File(ATFile):
 
     security.declareProtected(View, 'index_html')
     def index_html(self, REQUEST, RESPONSE):
-        """ Redirect to the default view """
-        return RESPONSE.redirect(self.absolute_url() + "/view")
+        """ Redirect to the default view or download view """
+
+        if redirect_to_download_by_default(self):
+            return RESPONSE.redirect(self.absolute_url() + '/download')
+        else:
+            return RESPONSE.redirect(self.absolute_url() + "/view")
 
     security.declarePrivate('getIndexValue')
 

--- a/ftw/file/profiles/default/metadata.xml
+++ b/ftw/file/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1512</version>
+  <version>1513</version>
     <dependencies>
         <dependency>profile-ftw.calendarwidget:default</dependency>
     </dependencies>

--- a/ftw/file/profiles/default/propertiestool.xml
+++ b/ftw/file/profiles/default/propertiestool.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_properties" meta_type="Plone Properties Tool">
- <object name="site_properties" meta_type="Plone Property Sheet">
-  <property name="typesUseViewActionInListings" type="lines" purge="False">
-   <element value="File" remove="True"/>
-  </property>
- </object>
-</object>

--- a/ftw/file/testing.py
+++ b/ftw/file/testing.py
@@ -1,15 +1,24 @@
+from ftw.builder.session import BuilderSession
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import set_builder_session_factory
+from ftw.testing import FunctionalSplinterTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
-from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import IntegrationTesting
-from plone.app.testing import FunctionalTesting
-from zope.configuration import xmlconfig
 from plone.testing.z2 import installProduct
+from zope.configuration import xmlconfig
+
+
+def functional_session_factory():
+    sess = BuilderSession()
+    sess.auto_commit = True
+    return sess
 
 
 class FtwFileLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -26,5 +35,8 @@ class FtwFileLayer(PloneSandboxLayer):
 FTW_FILE_FIXTURE = FtwFileLayer()
 FTW_FILE_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_FILE_FIXTURE, ), name="ftw.file:Integration")
-FTW_FILE_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(FTW_FILE_FIXTURE, ), name="ftw.file:Functional")
+
+FTW_FILE_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+    bases=(FTW_FILE_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="ftw.file:Functional")

--- a/ftw/file/tests/test_download_redirection.py
+++ b/ftw/file/tests/test_download_redirection.py
@@ -1,0 +1,42 @@
+from Products.CMFCore.utils import getToolByName
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
+from ftw.testing import browser
+from ftw.testing.pages import Plone
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.testing import login
+from unittest2 import TestCase
+
+
+class TestDownloadRedirection(TestCase):
+
+    layer = FTW_FILE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        portal = self.layer['portal']
+        acl_users = getToolByName(portal, 'acl_users')
+        acl_users.userFolderAddUser('reader', TEST_USER_PASSWORD,
+                                    ['Reader'], [])
+        acl_users.userFolderAddUser('contributor', TEST_USER_PASSWORD,
+                                    ['Contributor'], [])
+
+        login(portal, 'contributor')
+
+    def test_redirects_to_details_view_when_i_can_edit(self):
+        obj = create(Builder('file'))
+        Plone().login('contributor')
+
+        browser().visit(obj.absolute_url())
+
+        self.assertEquals('http://nohost/plone/file/view',
+                          browser().url)
+
+    def test_redirects_to_download_when_i_cannot_edit(self):
+        obj = create(Builder('file'))
+        Plone().login('reader')
+
+        browser().visit(obj.absolute_url())
+
+        self.assertEquals('http://nohost/plone/file/download',
+                          browser().url)

--- a/ftw/file/tests/test_utils.py
+++ b/ftw/file/tests/test_utils.py
@@ -1,0 +1,67 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.file.testing import FTW_FILE_INTEGRATION_TESTING
+from ftw.file.utils import redirect_to_download_by_default
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+class TestRedirectToDownloadByDefault(TestCase):
+
+    layer = FTW_FILE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+
+    def test_should_return_True_for_anonymous_users(self):
+        login(self.portal, TEST_USER_NAME)
+        obj = create(Builder('file'))
+        logout()
+
+        self.assertTrue(
+            redirect_to_download_by_default(obj),
+            'An anonymous user should be redirected to the downloads view.')
+
+    def test_should_return_True_for_anonymous_users_with_forced_border(self):
+        login(self.portal, TEST_USER_NAME)
+        obj = create(Builder('file'))
+        logout()
+
+        obj.REQUEST.other['enable_border'] = True
+        self.assertTrue(
+            redirect_to_download_by_default(obj),
+            'An anonymous user should be redirected to the downloads view, '
+            'even when enable_border is True.')
+
+        self.assertTrue(
+            obj.REQUEST.get('enable_border'),
+            'enable_border should not be removed from the request')
+
+    def test_should_return_False_for_editors(self):
+        login(self.portal, TEST_USER_NAME)
+        obj = create(Builder('file'))
+        setRoles(self.portal, TEST_USER_ID, ['Editor'])
+
+        self.assertFalse(
+            redirect_to_download_by_default(obj),
+            'An editor should not be redirected to the downloads view.')
+
+    def test_should_return_False_for_editors_in_previewish_mode(self):
+        login(self.portal, TEST_USER_NAME)
+        obj = create(Builder('file'))
+        setRoles(self.portal, TEST_USER_ID, ['Editor'])
+
+        obj.REQUEST.other['disable_border'] = True
+        self.assertFalse(
+            redirect_to_download_by_default(obj),
+            'An editor should not be redirected to the downloads view, '
+            'even when disable_border is True.')
+
+        self.assertTrue(
+            obj.REQUEST.get('disable_border'),
+            'disable_border should not be removed from the request')

--- a/ftw/file/tests/test_view.py
+++ b/ftw/file/tests/test_view.py
@@ -37,7 +37,7 @@ class TestFileName(TestCase):
         transaction.commit()
 
     def is_author_visible(self):
-        self.browser.open(self.context.absolute_url())
+        self.browser.open(self.context.absolute_url() + '/view')
         return '<th>Author</th>' in self.browser.contents
 
     def test_logged_in_user_sees_author_when_allowAnonymousViewAbout(self):

--- a/ftw/file/upgrades/configure.zcml
+++ b/ftw/file/upgrades/configure.zcml
@@ -79,4 +79,23 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1512 -> 1513 -->
+    <genericsetup:upgradeStep
+        title="ftw.file.upgrades.1513: Enable view action in listings (typesUseViewActionInListings)"
+        description=""
+        source="1512"
+        destination="1513"
+        handler="ftw.file.upgrades.to_1513.EnableViewActionInListings"
+        profile="ftw.file:default"
+        />
+
+    <genericsetup:registerProfile
+        name="1513"
+        title="ftw.file.upgrades.1513"
+        description=""
+        directory="profiles/1513"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/file/upgrades/profiles/1513/propertiestool.xml
+++ b/ftw/file/upgrades/profiles/1513/propertiestool.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="site_properties" meta_type="Plone Property Sheet">
+
+        <property name="typesUseViewActionInListings"
+                  type="lines" purge="False">
+            <element value="File" />
+        </property>
+
+    </object>
+
+</object>

--- a/ftw/file/upgrades/to_1513.py
+++ b/ftw/file/upgrades/to_1513.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableViewActionInListings(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.file.upgrades:1513')

--- a/ftw/file/utils.py
+++ b/ftw/file/utils.py
@@ -1,0 +1,27 @@
+
+
+def redirect_to_download_by_default(context):
+    """Returns True if the default view of the file (context) should
+    redirect to the download view.
+    """
+
+    request = context.REQUEST
+
+    border_was_force_disabled = request.get('disable_border')
+    if border_was_force_disabled:
+        del request.other['disable_border']
+
+    border_was_force_enabled = request.get('enable_border')
+    if border_was_force_enabled:
+        del request.other['enable_border']
+
+    try:
+        plone_view = context.restrictedTraverse('@@plone')
+        is_border_visible = plone_view.showEditableBorder()
+        return not is_border_visible
+
+    finally:
+        if border_was_force_disabled:
+            request.other['disable_border'] = border_was_force_disabled
+        if border_was_force_enabled:
+            request.other['enable_border'] = border_was_force_enabled

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ tests_require = [
     'plone.app.testing',
     'plone.mocktestcase',
     'pyquery',
+    'ftw.builder',
+    'ftw.testing[splinter]',
     ]
 
 setup(name='ftw.file',

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,3 +3,4 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
+    ftw.builder


### PR DESCRIPTION
Redirect users without any modifying permissions (without editable border)
to the download when not hitting a specific view.
Also add File back to allowAnonymousViewAbout for making sure that /view
is added in the navigation.

This mostly solves #13 (without adding extensions for statistics)
