### PR TITLE
Fix regression in download redirect with unicode filenames.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix regression in download redirect with unicode filenames.
+  [jone]
 
 
 1.7.0 (2013-07-18)

--- a/ftw/file/browser/download.py
+++ b/ftw/file/browser/download.py
@@ -13,7 +13,11 @@ class DownloadFileView(DownloadArchetypeFile):
         if not content:
             return super(DownloadFileView, self).__call__()
 
-        filename = urllib.quote(content.filename)
+        filename = content.filename
+        if isinstance(filename, unicode):
+            filename = filename.encode('utf-8')
+        filename = urllib.quote(filename)
+
         download_url = '/'.join((
                 self.context.absolute_url(),
                 '@@download',

--- a/ftw/file/tests/test_download_redirection.py
+++ b/ftw/file/tests/test_download_redirection.py
@@ -97,3 +97,20 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
             browser().url)
 
         self.assertEquals('PDF CONTENT', browser().html)
+
+    def test_supports_unicode_special_characters_in_filename(self):
+        obj = create(
+            Builder('file')
+            .titled('Document')
+            .attach_file_containing(
+                'PDF CONTENT',
+                name='w\xc3\xb6rter & bilder.pdf'.decode('utf-8')))
+
+        Plone().login().visit(obj, 'download')
+
+        self.assertEquals(
+            'http://nohost/plone/document/@@download/' + \
+                'file/w%C3%B6rter%20%26%20bilder.pdf',
+            browser().url)
+
+        self.assertEquals('PDF CONTENT', browser().html)


### PR DESCRIPTION
Fixes an encoding problem when the filename is unicode:

``` python
Traceback (innermost last):

Module ZPublisher.Publish, line 60, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 46, in call_object
Module ftw.file.content.file, line 85, in download
Module ftw.file.browser.download, line 16, in __call__
Module urllib, line 1282, in quote
KeyError: u'\xfc'
```
