### PR TITLE
Show Backreferences on file_view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Don't journalize when our user has no id.
   [tschanzt]
 
+- Show Backreferences on file_view.
+  [tschanzt]
+
 
 1.8.1 (2014-02-10)
 ------------------

--- a/ftw/file/locales/de/LC_MESSAGES/ftw.file.po
+++ b/ftw/file/locales/de/LC_MESSAGES/ftw.file.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-12-09 14:13+0000\n"
+"POT-Creation-Date: 2014-02-26 15:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,12 +16,12 @@ msgstr ""
 msgid "Action"
 msgstr "Aktion"
 
-#: ./ftw/file/browser/file_view.pt:43
+#: ./ftw/file/browser/file_view.pt:34
 #: ./ftw/file/viewlets/content_history.pt:11
 msgid "Author"
 msgstr "Autor"
 
-#: ./ftw/file/browser/file_view.pt:59
+#: ./ftw/file/browser/file_view.pt:50
 msgid "Classification"
 msgstr "Abgelegt unter"
 
@@ -29,16 +29,16 @@ msgstr "Abgelegt unter"
 msgid "Comment"
 msgstr "Kommentar"
 
-#: ./ftw/file/browser/file_view.pt:35
+#: ./ftw/file/browser/file_view.pt:26
 #: ./ftw/file/viewlets/content_history.pt:10
 msgid "Date"
 msgstr "Datum"
 
-#: ./ftw/file/browser/file_view.pt:39
+#: ./ftw/file/browser/file_view.pt:30
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ./ftw/file/browser/file_view.pt:27
+#: ./ftw/file/browser/file_view.pt:18
 msgid "File"
 msgstr "Datei"
 
@@ -46,11 +46,11 @@ msgstr "Datei"
 msgid "Journal"
 msgstr "Journal"
 
-#: ./ftw/file/browser/file_view.pt:55
+#: ./ftw/file/browser/file_view.pt:46
 msgid "Modified"
 msgstr "Letzte Änderung"
 
-#: ./ftw/file/browser/file_view.pt:69
+#: ./ftw/file/browser/file_view.pt:61
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -58,11 +58,12 @@ msgstr "Vorschau"
 msgid "download"
 msgstr "herunterladen"
 
-#: ./ftw/file/content/file.py:57
+#: ./ftw/file/content/file.py:65
 msgid "help_document_date"
 msgstr "Geben Sie das Datum der Datei ein. Dies ist entweder das aktuelle Datum oder das Datum, auf welches sich der Inhalt der Datei bezieht (Sitzung, Anlass, etc...)"
 
-#: ./ftw/file/content/file.py:48
+#. Default: "Insert a filename if you want to change the original filename. The extension (i.e. .docx) will not be modified"
+#: ./ftw/file/content/file.py:52
 msgid "help_origin_filename"
 msgstr "Geben Sie einen Dokumentnamen ein falls Sie den Namen der Originaldatei ändern möchten. Die Dateierweiterung (z.B. .docx) wird dabei nicht geändert."
 
@@ -72,12 +73,12 @@ msgid "label_anonymous_user"
 msgstr "Anonymer Benutzer"
 
 #. Default: "Document Date"
-#: ./ftw/file/content/file.py:56
+#: ./ftw/file/content/file.py:64
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "File"
-#: ./ftw/file/content/file.py:39
+#: ./ftw/file/content/file.py:43
 msgid "label_file"
 msgstr "Datei"
 
@@ -87,8 +88,13 @@ msgid "label_file_downloaded"
 msgstr "Datei heruntergeladen   "
 
 #. Default: "Filename"
-#: ./ftw/file/content/file.py:47
+#: ./ftw/file/content/file.py:51
 msgid "label_origin_filename"
 msgstr "Dokumentname"
+
+#. Default: "Referenced By"
+#: ./ftw/file/viewlets/related_items.pt:48
+msgid "label_referenced_by"
+msgstr "Referenziert durch"
 
 

--- a/ftw/file/locales/ftw.file.pot
+++ b/ftw/file/locales/ftw.file.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-12-09 14:13+0000\n"
+"POT-Creation-Date: 2014-02-26 15:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,12 +21,12 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:43
+#: ./ftw/file/browser/file_view.pt:34
 #: ./ftw/file/viewlets/content_history.pt:11
 msgid "Author"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:59
+#: ./ftw/file/browser/file_view.pt:50
 msgid "Classification"
 msgstr ""
 
@@ -34,16 +34,16 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:35
+#: ./ftw/file/browser/file_view.pt:26
 #: ./ftw/file/viewlets/content_history.pt:10
 msgid "Date"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:39
+#: ./ftw/file/browser/file_view.pt:30
 msgid "Description"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:27
+#: ./ftw/file/browser/file_view.pt:18
 msgid "File"
 msgstr ""
 
@@ -51,11 +51,11 @@ msgstr ""
 msgid "Journal"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:55
+#: ./ftw/file/browser/file_view.pt:46
 msgid "Modified"
 msgstr ""
 
-#: ./ftw/file/browser/file_view.pt:69
+#: ./ftw/file/browser/file_view.pt:61
 msgid "Preview"
 msgstr ""
 
@@ -63,11 +63,12 @@ msgstr ""
 msgid "download"
 msgstr ""
 
-#: ./ftw/file/content/file.py:57
+#: ./ftw/file/content/file.py:65
 msgid "help_document_date"
 msgstr ""
 
-#: ./ftw/file/content/file.py:48
+#. Default: "Insert a filename if you want to change the original filename. The extension (i.e. .docx) will not be modified"
+#: ./ftw/file/content/file.py:52
 msgid "help_origin_filename"
 msgstr ""
 
@@ -77,12 +78,12 @@ msgid "label_anonymous_user"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./ftw/file/content/file.py:56
+#: ./ftw/file/content/file.py:64
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "File"
-#: ./ftw/file/content/file.py:39
+#: ./ftw/file/content/file.py:43
 msgid "label_file"
 msgstr ""
 
@@ -92,7 +93,12 @@ msgid "label_file_downloaded"
 msgstr ""
 
 #. Default: "Filename"
-#: ./ftw/file/content/file.py:47
+#: ./ftw/file/content/file.py:51
 msgid "label_origin_filename"
+msgstr ""
+
+#. Default: "Referenced By"
+#: ./ftw/file/viewlets/related_items.pt:48
+msgid "label_referenced_by"
 msgstr ""
 

--- a/ftw/file/tests/test_relateditems.py
+++ b/ftw/file/tests/test_relateditems.py
@@ -1,0 +1,54 @@
+from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
+from unittest2 import TestCase
+from ftw.builder import create
+from ftw.builder import Builder
+from ftw.testbrowser import browsing
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+import transaction
+
+
+class TestFileName(TestCase):
+
+    layer = FTW_FILE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+        self.file1 = create(Builder('file').titled("file1"))
+        self.file2 = create(Builder('file').titled("file2"))
+
+    @browsing
+    def test_show_relateditems(self, browser):
+        self.file1.Schema().get('relatedItems').set(self.file1,
+                                                    self.file2.UID())
+        transaction.commit()
+        browser.login().open(self.file1.absolute_url())
+        box = browser.css('#relatedItemBox a')
+        self.assertEqual(['file2'], box.text)
+
+    @browsing
+    def test_show_referenced_by(self, browser):
+        self.file1.Schema().get('relatedItems').set(self.file1,
+                                                    self.file2.UID())
+        transaction.commit()
+        browser.login().open(self.file2.absolute_url())
+        box = browser.css('#referencedByBox a')
+        self.assertEqual(['file1'], box.text)
+
+    @browsing
+    def test_show_circular(self, browser):
+        self.file1.Schema().get('relatedItems').set(self.file1,
+                                                    self.file2.UID())
+        self.file2.Schema().get('relatedItems').set(self.file2,
+                                                    self.file1.UID())
+
+        transaction.commit()
+        browser.login().open(self.file2.absolute_url())
+        ref_box = browser.css('#referencedByBox')
+        self.assertEqual([], ref_box.text)
+        rel_box = browser.css('#relatedItemBox a')
+        self.assertEqual(['file1'], rel_box.text)

--- a/ftw/file/viewlets/configure.zcml
+++ b/ftw/file/viewlets/configure.zcml
@@ -11,4 +11,14 @@
         permission="zope2.View"
         />
 
+    <!-- The related items -->
+    <browser:viewlet
+        name="plone.belowcontentbody.relateditems"
+        manager="plone.app.layout.viewlets.interfaces.IBelowContentBody"
+        class=".related_items.FileRelatedItems"
+        view="ftw.file.browser.file_view.FileView"
+        for="ftw.file.interfaces.IFile"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/file/viewlets/related_items.pt
+++ b/ftw/file/viewlets/related_items.pt
@@ -1,0 +1,73 @@
+<div class="relatedItems"
+     i18n:domain="plone">
+    <div class="visualClear" id="clear-space-before-relatedItemBox"><!-- --></div>
+    <dl id="relatedItemBox"
+              tal:define="related view/related_items;
+                          ploneview nocall:context/@@plone;
+                          normalizeString nocall:ploneview/normalizeString;
+                          tools nocall:context/@@plone_tools;
+                          wf_tool tools/workflow;
+                          getInfoFor python:wf_tool.getInfoFor;
+                          site_properties context/portal_properties/site_properties;
+                          use_view_action site_properties/typesUseViewActionInListings|python:();"
+                tal:condition="related">
+        <dt i18n:translate="label_related_items">Related content</dt>
+        <tal:related repeat="item related">
+            <dd tal:define="
+                    desc                item/Description;
+                    item_icon           python:ploneview.getIcon(item);
+                    item_type           item/portal_type;
+                    item_type_class     python:'contenttype-' + normalizeString(item_type);
+                    item_wf_state       item/review_state|python: getInfoFor(item, 'review_state', '');
+                    item_wf_state_class python: 'state-' + normalizeString(item_wf_state);
+                    item_url            item/getURL|item/absolute_url;
+                    item_url            python:(item_type in use_view_action) and item_url+'/view' or item_url">
+                <span tal:attributes="class item_type_class">
+                    <img tal:replace="structure item_icon/html_tag" />
+                    <a href="" class=""
+                       tal:attributes="href  item_url;
+                                       title desc;
+                                       class string:$item_wf_state_class"
+                       tal:content="item/pretty_title_or_id">
+                        Related Item
+                    </a>
+                </span>
+            </dd>
+        </tal:related>        
+    </dl>
+    <dl id="referencedByBox"
+              tal:define="referenced view/referenced_by;
+                          ploneview nocall:context/@@plone;
+                          normalizeString nocall:ploneview/normalizeString;
+                          tools nocall:context/@@plone_tools;
+                          wf_tool tools/workflow;
+                          getInfoFor python:wf_tool.getInfoFor;
+                          site_properties context/portal_properties/site_properties;
+                          use_view_action site_properties/typesUseViewActionInListings|python:();"
+             tal:condition="referenced">
+          <dt i18n:domain="ftw.file" i18n:translate="label_referenced_by">Referenced by</dt>
+          <tal:referenced repeat="item referenced">
+              <dd tal:define="
+                      desc                item/Description;
+                      item_icon           python:ploneview.getIcon(item);
+                      item_type           item/portal_type;
+                      item_type_class     python:'contenttype-' + normalizeString(item_type);
+                      item_wf_state       item/review_state|python: getInfoFor(item, 'review_state', '');
+                      item_wf_state_class python: 'state-' + normalizeString(item_wf_state);
+                      item_url            item/getURL|item/absolute_url;
+                      item_url            python:(item_type in use_view_action) and item_url+'/view' or item_url">
+                  <span tal:attributes="class item_type_class">
+                      <img tal:replace="structure item_icon/html_tag" />
+                      <a href="" class=""
+                         tal:attributes="href  item_url;
+                                         title desc;
+                                         class string:$item_wf_state_class"
+                         tal:content="item/pretty_title_or_id">
+                          Related Item
+                      </a>
+                  </span>
+              </dd>
+          </tal:referenced>        
+        </dl>  
+        
+</div>

--- a/ftw/file/viewlets/related_items.py
+++ b/ftw/file/viewlets/related_items.py
@@ -1,0 +1,19 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.layout.viewlets.content import ContentRelatedItems
+from Products.CMFCore.utils import getToolByName
+
+
+class FileRelatedItems(ContentRelatedItems):
+
+    index = ViewPageTemplateFile("related_items.pt")
+
+    def referenced_by(self):
+        mem_tool = getToolByName(self.context, 'portal_membership')
+        backrefs = self.context.getBackReferences()
+        related_items = self.context.getRawRelatedItems()
+        backref_list = []
+        for item in backrefs:
+            if not item.UID() in related_items and mem_tool.checkPermission(
+                'View', item):
+                backref_list.append(item)
+        return backref_list

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_require = [
     'pyquery',
     'ftw.builder',
     'ftw.testing[splinter]',
+    'ftw.testbrowser',
     ]
 
 setup(name='ftw.file',


### PR DESCRIPTION
@maethu We now show backreferences in file view.

When a file references another one:
![bildschirmfoto 2014-02-27 um 11 38 52](https://f.cloud.github.com/assets/358342/2283011/2a80ae6a-9fb7-11e3-9fef-87455a7dc987.png)

when it is refererenced:
![bildschirmfoto 2014-02-27 um 11 38 45](https://f.cloud.github.com/assets/358342/2283012/2a8117e2-9fb7-11e3-91e8-de2f7174a791.png)
when both things are true:
![bildschirmfoto 2014-02-27 um 14 34 33](https://f.cloud.github.com/assets/358342/2283010/2a801aa4-9fb7-11e3-852a-cf97c0adbe04.png)

Note If we have circular references we only show that it references the other file not that it gets referenced by it.