### PR TITLE
Catch OverflowError for unkown PSD formats.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Catch OverflowError for unkown PSD formats.
+  [jone]
+
 - Don't journalize when our user has no id.
   [tschanzt]
 

--- a/ftw/file/browser/scaling.py
+++ b/ftw/file/browser/scaling.py
@@ -22,6 +22,11 @@ class FtwImageScaling(ImageScaling):
             return create(self.context, direction=direction, **parameters)
         except IOError:
             return None
+        except OverflowError:
+            # Some PSDs throw an OverflowError, probably because of unsupported
+            # file formats.
+            # https://github.com/4teamwork/ftw.file/issues/29
+            return None
         except (ConflictError, KeyboardInterrupt):
             raise
         except Exception:


### PR DESCRIPTION
When opening never PSD files with PIL, an `OverflowError` might be raised.
This is probably because of unsupported PSD format.
Since we cannot fix the error we just catch it and do not display any preview in this case.

Closes #29 

@maethu 
