### PR TITLE
Override origin name if file is uploaded.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- When replacing the file, use the new filename given by the file.
+  [lknoepfel]
+
 - Catch OverflowError for unkown PSD formats.
   [jone]
 

--- a/ftw/file/configure.zcml
+++ b/ftw/file/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ftw.file">
 
   <includeDependencies package="." />
@@ -39,5 +40,9 @@
   <adapter
       for="ftw.file.fields.FileField"
       factory="plone.app.imaging.scaling.ImageScaleFactory" />
+
+  <browser:resource
+      file="resources/hideOriginFilenameField.js"
+      name="hideOriginFilenameField.js" />
 
 </configure>

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -48,6 +48,7 @@ FileSchema = ATFileSchema.copy() + atapi.Schema((
         name='originFilename',
         required=False,
         widget=StringWidget(
+            helper_js=("++resource++hideOriginFilenameField.js", ),
             label=_(u'label_origin_filename', default=u'Filename'),
             description=_(
                 u'help_origin_filename',
@@ -146,6 +147,10 @@ class File(ATFile):
         """Overrides the filename with the given value.
         It keeps the old extenstion.
         """
+        # file_delete contains '' if a file is uploaded, otherwise 'nochange'
+        if self.REQUEST.form.get('file_delete', 'nochange') != 'nochange':
+            return
+
         filename = self.getFilename()
         if not value or not filename:
             return

--- a/ftw/file/resources/hideOriginFilenameField.js
+++ b/ftw/file/resources/hideOriginFilenameField.js
@@ -1,0 +1,8 @@
+$(function() {
+
+    $('#archetypes-fieldname-file input[type=radio]').change(function() {
+        display = ($('#file_upload').is(':checked')) ? 'None' : '';
+        $('#archetypes-fieldname-originFilename').css('display', display);
+    });
+
+})

--- a/ftw/file/tests/test_filename.py
+++ b/ftw/file/tests/test_filename.py
@@ -1,4 +1,7 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from StringIO import StringIO
@@ -93,3 +96,20 @@ class TestFileName(TestCase):
         self.set_filedata('dummyfile')
         self.context.setOriginFilename(u'\xfcber')
         self.assertEqual('\xc3\xbcber', self.context.getFilename())
+
+    @browsing
+    def test_origin_filename_is_set_if_no_file_is_uploaded(self, browser):
+        existingfile = create(Builder('file').with_dummy_content())
+        browser.login().open(existingfile, view='edit')
+        browser.fill({'Filename': 'newFilename'}).submit()
+        self.assertEquals('newFilename.doc', existingfile.getFilename())
+
+    @browsing
+    def test_origin_filename_is_filename_of_uploaded_file(self, browser):
+        existingfile = create(Builder('file').with_dummy_content())
+        browser.login().open(existingfile, view='edit')
+        browser.fill({
+            'file_delete': '',
+            'file_file': ('Raw file data', 'newfile.txt', 'text/plain')
+        }).submit()
+        self.assertEqual('newfile.txt', existingfile.getFilename())

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'plone.mocktestcase',
     'pyquery',
     'ftw.builder',
+    'ftw.testbrowser',
     'ftw.testing[splinter]',
     ]
 


### PR DESCRIPTION
- Added js to hide the filename field if the user selects a file. (hide effect when he clicks on the radio button)
- The now hidden field still sends its pre filled content. This content gets ignored if a file is uploaded so the filename of the uploaded file stays unchanged.

@maethu 
