### PR TITLE
Only load ftw.activity 1.x representation if ftw.activity 1.x is installed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Only load ftw.activity 1.x representation if ftw.activity 1.x is installed.
+  [mathias.leimgruber]
+
 - Show a hint about the imminent file replacement in the dropzone overlay.
   [mbaechtold]
 

--- a/ftw/file/browser/configure.zcml
+++ b/ftw/file/browser/configure.zcml
@@ -35,8 +35,11 @@
         />
 
     <configure zcml:condition="installed ftw.activity">
-      <adapter factory=".activity.FileRepresentation"
-               provides="ftw.activity.interfaces.IActivityRepresentation" />
+      <include package="ftw.activity" />
+      <configure zcml:condition="not-have ftw-activity-2">
+        <adapter factory=".activity.FileRepresentation"
+                 provides="ftw.activity.interfaces.IActivityRepresentation" />
+      </configure>
     </configure>
 
 </configure>

--- a/ftw/file/tests/test_activity.py
+++ b/ftw/file/tests/test_activity.py
@@ -1,15 +1,24 @@
-from ftw.activity.interfaces import IActivityRepresentation
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from unittest2 import skipUnless
 from unittest2 import TestCase
 from zope.component import getMultiAdapter
 import os.path
 
 
+HAS_ACTIVITY_1 = False
+try:
+    from ftw.activity.interfaces import IActivityRepresentation
+    HAS_ACTIVITY_1 = True
+except ImportError:
+    HAS_ACTIVITY_1 = False
+
+
+@skipUnless(HAS_ACTIVITY_1, 'Detected ftw.activity 2.0')
 class TestActivityRepresentation(TestCase):
     layer = FTW_FILE_FUNCTIONAL_TESTING
 


### PR DESCRIPTION
ftw.activity 2.x was refactered and has a different implementation of
activity representation.