### PR TITLE
fix outputfilter so it works with scaled images.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix Outputfilter, so it does work with scaled images.
+  [tschanzt]
+
 - Integrate ftw.file images with TinyMCE.
   [lknoepfel]
 

--- a/ftw/file/custom_outputfilter.py
+++ b/ftw/file/custom_outputfilter.py
@@ -1,16 +1,18 @@
 from plone.outputfilters.filters.resolveuid_and_caption import ResolveUIDAndCaptionFilter
+from plone.app.imaging.interfaces import IImageScale
 
 class FtwFileFilter(ResolveUIDAndCaptionFilter):
 
     def resolve_image(self, src):
         (image, fullimage, source, description) = ResolveUIDAndCaptionFilter.resolve_image(self, src)
-
-        url = ''
-        obj, subpath, appendix = self.resolve_link(src)
-        if image:
-            url = image.absolute_url()
-        if isinstance(url, unicode):
-            url = url.encode('utf8')
-        src = '/'.join([url, subpath, appendix])
-
+        if not IImageScale.providedBy(image):
+            url = ''
+            obj, subpath, appendix = self.resolve_link(src)
+            if image:
+                url = image.absolute_url()
+            if isinstance(url, unicode):
+                url = url.encode('utf8')
+            src = '/'.join([url, subpath, appendix])
+        else:
+            src = image.absolute_url()
         return image, fullimage, src, description

--- a/ftw/file/tests/test_outputfilter.py
+++ b/ftw/file/tests/test_outputfilter.py
@@ -1,0 +1,44 @@
+from unittest2 import TestCase
+from ftw.builder import create
+from ftw.builder import Builder
+from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
+from StringIO import StringIO
+from plone.app.testing import login
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+from ftw.testbrowser import browsing
+from zope.annotation.interfaces import IAnnotations
+import os
+
+
+class TestOutputfilter(TestCase):
+
+    layer = FTW_FILE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+        self.obj = create(Builder('file').attach_file_containing(
+                          self.asset('transparent.gif'),'transparent.gif'))
+
+
+    @browsing
+    def test_outputfilter_scaled(self, browser):
+        page = browser.login().visit(self.obj)
+        annos = IAnnotations(self.obj)
+        scales = annos.items()[1][1].keys()
+        for scale in scales:
+            if isinstance(scale, str):
+                scale_uid = scale
+        image = page.css('.fileListing img')[1].node
+        self.assertEqual("http://nohost/plone/file/@@images/"+ scale_uid +".jpeg",
+                         image.attrib['src'])
+
+
+    def asset(self, filename):
+        path = os.path.join(os.path.dirname(__file__),
+                            'assets',
+                            filename)
+        with open(path, 'r') as fh:
+            return fh.read()


### PR DESCRIPTION
@jone I adjusted the output filter so it returns the image url correctly when the plone filter already returns a ImageScale as Image.
