### PR TITLE
Remove icon effect when replacing file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Remove icon effect when replacing file.
+  [jone]
+
 - Add adjustments to integrate bumblebee
     - Trigger event dndUploadViewUpdated if drag&drop is finished
     - Trigger ObjectEditedEvent from Products.Archetypes instead zope.

--- a/ftw/file/resources/uploader.css
+++ b/ftw/file/resources/uploader.css
@@ -58,8 +58,6 @@
   text-align: center; }
   #dropzone.hover {
     box-shadow: 0 0px 10px 0px rgba(0, 0, 0, 0.5); }
-    #dropzone.hover #ftw-file-upload {
-      transform: rotate(360deg); }
   #dropzone.done #ftw-file-upload {
     display: none; }
   #dropzone.done.hover {


### PR DESCRIPTION
Remove animation of the upload icon when replacing a file.
Because I personally do not like the animation and it keeps repeating while just moving the mouse around, which is really strange.
The first impression for me is that it is a bug, therefore I've removed it.
![2015-09-08_16-47-30](https://cloud.githubusercontent.com/assets/7469/9737961/83f42176-5649-11e5-8459-b09e1715b8d4.png)
