### PR TITLE
Details view: refactor template binding

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Details view: refactor template binding for easeier subclassing.
+  By moving the template binding to python code, subclasses can still render
+  the default template conditionally.
+  [jone]
 
 
 1.11.1 (2015-09-09)

--- a/ftw/file/browser/configure.zcml
+++ b/ftw/file/browser/configure.zcml
@@ -8,7 +8,6 @@
         for="..interfaces.IFile"
         name="file_view"
         class=".file_view.FileView"
-        template="file_view.pt"
         permission="zope2.View"
         />
 

--- a/ftw/file/browser/file_view.py
+++ b/ftw/file/browser/file_view.py
@@ -1,9 +1,15 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.file.utils import FileMetadata
 from Products.Five import BrowserView
 
 
 class FileView(BrowserView):
     """ View for ftw.file """
+
+    template = ViewPageTemplateFile('file_view.pt')
+
+    def __call__(self):
+        return self.template()
 
     def get_image_tag(self):
         return self.metadata.get_image_tag(


### PR DESCRIPTION
By moving the template binding to python code, subclasses can still render the default template conditionally.