### PR TITLE
Fix regression when trying to link files in TinyMCE.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,12 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
+- Fix regression when trying to link files in TinyMCE.
+  The problem was that only images were linkable.
+  [jone]
+
 - Fix tests for new colorbox version.
-  [tschanzt] 
+  [tschanzt]
 
 
 1.11.2 (2015-09-10)

--- a/ftw/file/browser/tinymce.py
+++ b/ftw/file/browser/tinymce.py
@@ -5,9 +5,23 @@ import json
 
 class FtwJSONFolderListing(JSONFolderListing):
 
-    def getListing(self, *args, **kwargs):
-        listing = super(FtwJSONFolderListing, self).getListing(*args, **kwargs)
-        listing_obj = json.loads(listing)
+    def getListing(self, filter_portal_types, rooted, document_base_url,
+                   upload_type=None, image_types=None):
+        listing = super(FtwJSONFolderListing, self).getListing(
+            filter_portal_types, rooted, document_base_url,
+            upload_type=upload_type, image_types=image_types)
+        if upload_type == 'Image':
+            listing = self.remove_files_which_are_not_images(listing)
+        return listing
+
+    def remove_files_which_are_not_images(self, json_encoded_listing):
+        """The super getListing call returns all ftw.file files, no matter
+        if they are images or not.
+        When we require images, we therefore need to filter the files so
+        that we only return images.
+        """
+
+        listing_obj = json.loads(json_encoded_listing)
 
         filtered_items = []
         for item in listing_obj['items']:


### PR DESCRIPTION
The problem was that only images were linkable.

/cc @mbaechtold 