### PR TITLE
Fix journal action translation for files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
+- Fix journal action translation for files
+  [elioschmutz]
+
 - Fix drag'n'drop for files in Firefox.
   [Kevin Bieri]
 

--- a/ftw/file/viewlets/content_history.pt
+++ b/ftw/file/viewlets/content_history.pt
@@ -22,7 +22,7 @@
                          action item/transition_title;
                          isVersion python:item['type']=='versioning'">
           <td>
-            <span class="historyAction" tal:content="action" i18n:translate=""
+            <span class="historyAction" tal:content="action" i18n:translate="" i18n:domain="plone"
                   tal:attributes="class string:historyAction state-${action}">action</span>
           </td>
           <td tal:content="python:view.toLocalizedTime(item['time'], long_format=True)" />


### PR DESCRIPTION
Some journalactions are not translated:

~~Image removed~~

This PR will fix this:

![bildschirmfoto 2016-01-05 um 14 29 09](https://cloud.githubusercontent.com/assets/557005/12116260/c4a7eb5e-b3b8-11e5-98e9-05d9ef58e7bb.png)
