### PR TITLE
Make documentDate required.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.11.5 (unreleased)
 -------------------
 
+- documentDate is now required.
+  https://github.com/4teamwork/ftw.file/issues/64
+  [elioschmutz]
+
 - Set batch size to 10. 50 is imho way to mutch, event 20 makes me scrolling 3 down.
   So 10 is imho OK. No? let's fight... or someone implements a configurable number.
   [mathias.leimgruber]

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -78,7 +78,7 @@ FileSchema = ATFileSchema.copy() + atapi.Schema((
     ),
     atapi.DateTimeField(
         'documentDate',
-        required=False,
+        required=True,
         default_method=DateTime,
         widget=FtwCalendarWidget(
             label=_(u'label_document_date', default=u'Document Date'),

--- a/ftw/file/upgrades/20160601223722_set_empty_document_date/upgrade.py
+++ b/ftw/file/upgrades/20160601223722_set_empty_document_date/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+
+
+class SetEmptyDocumentDate(UpgradeStep):
+    """Set empty document date.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'object_provides': 'ftw.file.interfaces.IFile'}
+        for obj in self.objects(query, 'Update empty documentDate'):
+
+            if obj.getDocumentDate():
+                # We skip files with a documentdate
+                continue
+
+            obj.setDocumentDate(obj.created())
+            obj.reindexObject(idxs=['documentDate'])


### PR DESCRIPTION
This PR makes the `documentDate` required.

This will solve sorting issues with the plone catalog if no `documentDate` was set.
See issue #64 for more information.

This PR comes up with following changes:

- required `documentDate`
- Upgradestep to set the `documnetDate` to the `creation`-Date if no `documentDate` is set.


There was no need to adjust the template because there where no checks if the `documentDate` is available or not. The utils method https://github.com/4teamwork/ftw.file/blob/master/ftw/file/utils.py#L109 has a fallback. If there was no `documentDate` it returned the current date. So we don't have to adjust anything else.

Before:
----------
![vorher](https://cloud.githubusercontent.com/assets/557005/15725461/5d193886-284c-11e6-8475-6006799bd0cb.gif)

After:
-------

![nachher](https://cloud.githubusercontent.com/assets/557005/15725467/660df6f2-284c-11e6-9932-61a4694738ba.gif)

closes #64 