### PR TITLE
Fix security declaration warnings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.6 (unreleased)
 -------------------
 
-- Fix security declarations for getOriginFilename. [jone]
+- Fix security declarations for getOriginFilename, is_image and getField. [jone]
 
 
 1.11.5 (2016-07-19)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix security declarations for getOriginFilename. [jone]
 
 
 1.11.5 (2016-07-19)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.11.6 (unreleased)
 -------------------
 
+- Simplify schema inheritance. [jone]
+
 - Fix security declarations for getOriginFilename, is_image and getField. [jone]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.11.6 (unreleased)
 -------------------
 
+- Eliminate bad security declarations through interface. [jone]
+
 - Simplify schema inheritance. [jone]
 
 - Fix security declarations for getOriginFilename, is_image and getField. [jone]

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -1,6 +1,5 @@
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime
-from Products.validation.validators import RegexValidator
 from ftw.calendarwidget.browser.widgets import FtwCalendarWidget
 from ftw.file import fileMessageFactory as _
 from ftw.file.config import PROJECTNAME
@@ -17,13 +16,14 @@ from Products.Archetypes.BaseContent import BaseContent
 from Products.Archetypes.Widget import StringWidget
 from Products.ATContentTypes.config import ICONMAP
 from Products.ATContentTypes.content.file import ATFile
-from Products.ATContentTypes.content.file import ATFileSchema
+from Products.ATContentTypes.content.schemata import ATContentTypeSchema
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from Products.validation import V_REQUIRED
 from Products.validation.config import validation
+from Products.validation.validators import RegexValidator
 from urllib import quote
 from ZODB.POSException import ConflictError
 from zope.interface import implements
@@ -44,7 +44,7 @@ origin_filename_validator = RegexValidator(
 validation.register(origin_filename_validator)
 
 
-FileSchema = ATFileSchema.copy() + atapi.Schema((
+FileSchema = ATContentTypeSchema.copy() + atapi.Schema((
     FileField(
         'file',
         required=True,

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -179,7 +179,7 @@ class File(ATFile):
 
         self.setFilename('{0}{1}'.format(value, path.splitext(filename)[1]))
 
-    security.declareProtected(ModifyPortalContent, 'getOriginFilename')
+    security.declareProtected(View, 'getOriginFilename')
     def getOriginFilename(self):
         """Gets the filename without extension
         """

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -233,10 +233,12 @@ class File(ATFile):
                 res = res[1:]
             return res
 
+    security.declarePublic('is_image')
     def is_image(self):
         file_ = self.getFile()
         return is_image(file_.getContentType())
 
+    security.declareProtected(View, 'getField')
     def getField(self, key, *args, **kwargs):
         if key == 'image':
             key = 'file'

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -17,6 +17,7 @@ from Products.Archetypes.Widget import StringWidget
 from Products.ATContentTypes.config import ICONMAP
 from Products.ATContentTypes.content.file import ATFile
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
+from Products.ATContentTypes.interfaces import IFileContent
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
@@ -107,7 +108,7 @@ for f in FileSchema.keys():
 class File(ATFile):
     """A file content type based on blobs.
     """
-    implements(IFile, IWorkflowHistoryJournalizable)
+    implements(IFile, IFileContent, IWorkflowHistoryJournalizable)
 
     meta_type = "FtwFile"
     schema = FileSchema

--- a/ftw/file/interfaces.py
+++ b/ftw/file/interfaces.py
@@ -1,10 +1,10 @@
-from Products.ATContentTypes.interfaces import IFileContent
+from plone.app.blob.interfaces import IBlobField
 from zope.component.interfaces import IObjectEvent
 from zope.interface import Attribute
-from plone.app.blob.interfaces import IBlobField
+from zope.interface import Interface
 
 
-class IFile(IFileContent):
+class IFile(Interface):
     """File marker interface.
     """
 

--- a/ftw/file/tests/test_filename.py
+++ b/ftw/file/tests/test_filename.py
@@ -100,7 +100,8 @@ class TestFileName(TestCase):
 
     @browsing
     def test_origin_filename_is_set_if_no_file_is_uploaded(self, browser):
-        existingfile = create(Builder('file').with_dummy_content())
+        existingfile = create(Builder('file').with_dummy_content()
+                              .titled('The File'))
         browser.login().open(existingfile, view='edit')
         browser.fill({'Filename': 'newFilename'}).submit()
         self.assertEquals('newFilename.doc', existingfile.getFilename())
@@ -117,7 +118,8 @@ class TestFileName(TestCase):
 
     @browsing
     def test_origin_filename_cannot_contain_slash(self, browser):
-        existingfile = create(Builder('file').with_dummy_content())
+        existingfile = create(Builder('file').with_dummy_content()
+                              .titled('The File'))
 
         browser.login()
 


### PR DESCRIPTION
Fix security declaration warnings
```
2016-11-21 14:46:53 WARNING SecurityInfo Conflicting security declarations for "getOriginFilename"
2016-11-21 14:46:53 WARNING SecurityInfo Class "File" had conflicting security declarations
2016-11-21 14:46:55 WARNING SecurityInfo Conflicting security declarations for "setFile"
2016-11-21 14:46:55 WARNING SecurityInfo Class "File" had conflicting security declarations
```

- **fix security declaration of getOriginFilename method.**
- **declare security for is_image and getField.**
- **inherit schema from ATContentTypeSchema.**
    The ATFileSchema inherits ATContentTypeSchema and adds the "file"
    field.
    As we do the same it does not make any sense to inherit ATFileSchema
    when we are overwriting the "file" field anyway.
- **Eliminate bad security declarations through interface.**
    By using the ZCML class-require-permission directive, all direct or
    indirect inherited interface method will be marked with the configured
    permission on the class.
    Usually we have no methods on content type interface, but in this
    situation we are actually inheriting the "getFile" and "setFile"
    methods, leading to an invalid security declaration for "setFile".
    
    Since the directive is actually not used we can simple skip it.
