### PR TITLE
Added option to download file with inline content-disposition header.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
+- Added option to download file with inline content-disposition header. [lknoepfel]
+
 - A new option on the file can be used to protect a file. Protected files
   cannot be deleted by anyone until the option is unchecked. [mbaechtold]
 

--- a/ftw/file/browser/download.py
+++ b/ftw/file/browser/download.py
@@ -31,6 +31,9 @@ class DownloadFileView(DownloadArchetypeFile):
                 field.getName(),
                 filename))
 
+        if 'inline' in self.request.form.keys():
+            download_url += '?inline=true'
+
         return self.request.RESPONSE.redirect(download_url)
 
     def call_download(self):
@@ -41,4 +44,8 @@ class DownloadFileView(DownloadArchetypeFile):
         if not field.checkPermission('r', context):
             raise Unauthorized()
 
-        return field.index_html(context, disposition='attachment')
+        disposition = 'attachment'
+        if 'inline' in self.request.form.keys():
+            disposition = 'inline'
+
+        return field.index_html(context, disposition=disposition)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '1.12.1.dev0'
 tests_require = [
     'ftw.activity',
     'ftw.builder',
-    'ftw.testbrowser',
+    'ftw.testbrowser >= 1.22',
     'ftw.testing[splinter]',
     'plone.app.testing',
     'plone.mocktestcase',


### PR DESCRIPTION
Fixes https://github.com/4teamwork/ftw.file/issues/34

I decided to use a GET parameter because tweaking a header should be an option of the download view and not a different view which does exactly the same as the download view except changing part of a header.
