### PR TITLE
Rewrite download redirection tests using ftw.testbrowser, drop dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Rewrite download redirection tests using ftw.testbrowser, drop dependency on
+  ftw.testing[splinter]. [lgraf]
 
 
 1.13.0 (2017-05-15)

--- a/ftw/file/testing.py
+++ b/ftw/file/testing.py
@@ -1,15 +1,15 @@
 from ftw.builder.session import BuilderSession
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing import FunctionalSplinterTesting
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.testing.z2 import installProduct
 from zope.component import eventtesting
 from zope.configuration import xmlconfig
-import ftw.file.tests.builders
+import ftw.file.tests.builders  # noqa
 
 
 def functional_session_factory():
@@ -44,7 +44,7 @@ FTW_FILE_FIXTURE = FtwFileLayer()
 FTW_FILE_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_FILE_FIXTURE, ), name="ftw.file:Integration")
 
-FTW_FILE_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+FTW_FILE_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_FILE_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="ftw.file:Functional")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ tests_require = [
     'ftw.activity',
     'ftw.builder',
     'ftw.testbrowser >= 1.22',
-    'ftw.testing[splinter]',
+    'ftw.testing',
     'plone.app.testing',
     'plone.mocktestcase',
     'pyquery',


### PR DESCRIPTION
Rewrite download redirection tests using `ftw.testbrowser` and drop dependency on `ftw.testing[splinter]` (which has been removed from `ftw.testing`).

Fixes current test failures.