### PR TITLE
Add option to disable the redirect to the download view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
+- A new registry record can be used to prevent redirects to the download
+  view of the file. [mbaechtold]
+
 - Rewrite download redirection tests using ftw.testbrowser, drop dependency on
   ftw.testing[splinter]. [lgraf]
 

--- a/ftw/file/profiles/default/registry.xml
+++ b/ftw/file/profiles/default/registry.xml
@@ -12,4 +12,11 @@
         </value>
     </record>
 
+    <record name="ftw.file.disable_download_redirect">
+        <field type="plone.registry.field.Bool">
+            <title>Disable redirecting to the download view</title>
+        </field>
+        <value>False</value>
+    </record>
+
 </registry>

--- a/ftw/file/tests/test_download_redirection.py
+++ b/ftw/file/tests/test_download_redirection.py
@@ -7,7 +7,9 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFCore.utils import getToolByName
+from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
+from zope.component import getUtility
 
 
 class TestDownloadRedirection(TestCase):
@@ -41,6 +43,25 @@ class TestDownloadRedirection(TestCase):
         self.assertEquals(
             'http://nohost/plone/file/@@download/file/test.doc',
             browser.url)
+
+    @browsing
+    def test_redirects_to_details_when_redirect_to_download_is_disabled(self, browser):
+        registry = getUtility(IRegistry)
+        registry['ftw.file.disable_download_redirect'] = True
+
+        obj = create(Builder('file'))
+
+        # Redirect users having the permission to edit file.
+        browser.login('contributor').visit(obj)
+
+        self.assertEquals('http://nohost/plone/file/view',
+                          browser.url)
+
+        # Redirect users not having the permission to edit file.
+        browser.login('reader').visit(obj)
+
+        self.assertEquals('http://nohost/plone/file/view',
+                          browser.url)
 
 
 class TestDownloadRedirectToURLWithFilename(TestCase):

--- a/ftw/file/upgrades/20171113100333_add_registry_record/registry.xml
+++ b/ftw/file/upgrades/20171113100333_add_registry_record/registry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<registry>
+
+    <record name="ftw.file.disable_download_redirect">
+        <field type="plone.registry.field.Bool">
+            <title>Disable redirecting to the download view</title>
+        </field>
+        <value>False</value>
+    </record>
+
+</registry>

--- a/ftw/file/upgrades/20171113100333_add_registry_record/upgrade.py
+++ b/ftw/file/upgrades/20171113100333_add_registry_record/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddRegistryRecord(UpgradeStep):
+    """Add registry record (disable download redirect).
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/file/utils.py
+++ b/ftw/file/utils.py
@@ -1,6 +1,8 @@
 from PIL import Image
 from plone import api
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
 
 
 def redirect_to_download_by_default(context):
@@ -18,7 +20,12 @@ def redirect_to_download_by_default(context):
     if border_was_force_enabled:
         del request.other['enable_border']
 
+    registry = getUtility(IRegistry)
+    disable_download_redirect = registry.get('ftw.file.disable_download_redirect', False)
+
     try:
+        if disable_download_redirect:
+            return False
         plone_view = context.restrictedTraverse('@@plone')
         is_border_visible = plone_view.showEditableBorder()
         return not is_border_visible


### PR DESCRIPTION
This is useful in intranets (having "bumblebee") where all authenticated users can view files. The users must not be redirected to the download view of the file. Instead they should be able to preview the file.