### PR TITLE
Adapter for IFileCreator used by zipextract

### DIFF
--- a/ftw/file/configure.zcml
+++ b/ftw/file/configure.zcml
@@ -62,6 +62,10 @@
   <adapter
       factory=".imaging.FtwFileImageScaleHandler" />
 
+  <adapter
+    zcml:condition="installed ftw.zipextract"
+    factory=".filecreator.FileCreator" />
+
   <subscriber
       for="ftw.file.interfaces.IFile
            OFS.interfaces.IObjectWillBeRemovedEvent"

--- a/ftw/file/filecreator.py
+++ b/ftw/file/filecreator.py
@@ -1,11 +1,11 @@
-from ftw.file.content.file import File
+from ftw.file.interfaces import IFile
 from ftw.zipextract.interfaces import IFileCreator
-from ftw.zipextract.interfaces import _ObjectCreator
+from ftw.zipextract.interfaces import ObjectCreatorBase
 from zope.component import adapts
 from zope.interface import implements
 
 
-class FileCreator(_ObjectCreator):
+class FileCreator(ObjectCreatorBase):
     implements(IFileCreator)
-    adapts(File)
+    adapts(IFile)
     portal_type = "File"

--- a/ftw/file/filecreator.py
+++ b/ftw/file/filecreator.py
@@ -1,0 +1,11 @@
+from ftw.file.content.file import File
+from ftw.zipextract.interfaces import IFileCreator
+from ftw.zipextract.interfaces import _ObjectCreator
+from zope.component import adapts
+from zope.interface import implements
+
+
+class FileCreator(_ObjectCreator):
+    implements(IFileCreator)
+    adapts(File)
+    portal_type = "File"


### PR DESCRIPTION
Implementation of the `IFileCreator` interface used by `ftw.zipextract`.
See: https://github.com/4teamwork/ftw.zipextract/pull/1