### PR TITLE
Introduce new permission "ftw.file: Edit date fields".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Protect the edit form tab (schemata) for the expiration date and effective date
+  with a separate permission. [mbaechtold]
 
 
 1.15.0 (2018-03-14)

--- a/ftw/file/content/file.py
+++ b/ftw/file/content/file.py
@@ -107,12 +107,17 @@ FileSchema = ATContentTypeSchema.copy() + atapi.Schema((
 FileSchema.registerLayer('marshall', BlobMarshaller())
 
 FileSchema['documentDate'].widget.show_hm = False
-# clean up schemata, means: set manage portal as write permission
-schematas = ['categorization', 'dates', 'ownership', 'settings', 'creators']
+
+schematas = ['categorization', 'ownership', 'settings', 'creators']
 for f in FileSchema.keys():
     field_ = FileSchema[f]
     if field_.schemata in schematas:
         field_.write_permission = 'ftw.file: Edit advanced fields'
+
+for f in FileSchema.keys():
+    field_ = FileSchema[f]
+    if field_.schemata == 'dates':
+        field_.write_permission = 'ftw.file: Edit date fields'
 
 
 class File(ATFile):

--- a/ftw/file/lawgiver.zcml
+++ b/ftw/file/lawgiver.zcml
@@ -12,7 +12,8 @@
 
     <lawgiver:map_permissions
         action_group="manage content settings"
-        permissions="ftw.file: Edit advanced fields"
+        permissions="ftw.file: Edit advanced fields,
+                     ftw.file: Edit date fields"
         />
 
     <lawgiver:ignore

--- a/ftw/file/permissions.zcml
+++ b/ftw/file/permissions.zcml
@@ -8,6 +8,11 @@
       />
 
   <permission
+      id="ftw.file.EditDateFields"
+      title="ftw.file: Edit date fields"
+      />
+
+  <permission
       id="ftw.file.ProtectFile"
       title="ftw.file: Protect file"
       />

--- a/ftw/file/profiles/default/rolemap.xml
+++ b/ftw/file/profiles/default/rolemap.xml
@@ -11,6 +11,11 @@
       <role name="Site Administrator" />
       <role name="Reviewer" />
     </permission>
+    <permission name="ftw.file: Edit date fields" acquire="False">
+      <role name="Manager" />
+      <role name="Site Administrator" />
+      <role name="Reviewer" />
+    </permission>
     <permission name="ftw.file: Protect file" acquire="True">
       <role name="Manager" />
       <role name="Site Administrator" />

--- a/ftw/file/tests/test_advanced_edit.py
+++ b/ftw/file/tests/test_advanced_edit.py
@@ -1,5 +1,7 @@
+from ftw.builder import Builder, create
 from ftw.file.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
+import transaction
 
 
 class TestAdvancedEdit(FunctionalTestCase):
@@ -19,5 +21,27 @@ class TestAdvancedEdit(FunctionalTestCase):
         fieldsets = browser.css('fieldset')
         self.assertEqual(
             ['Default', 'Categorization', 'Dates', 'Creators', 'Settings'],
+            fieldsets.css('legend').text
+        )
+
+    @browsing
+    def test_edit_date_fields(self, browser):
+        self.grant('Contributor')
+        file = create(Builder('file'))
+
+        # By default, a user having the role "Contributor" does not have the permission
+        # to edit the date fields.
+        browser.login().open(file, view='edit')
+        fieldsets = browser.css('fieldset')
+        self.assertEqual(len(fieldsets), 0, "We found some fieldsets although we did not expect any.")
+
+        # Grant the permission and make sure that the user is now able to edit the
+        # date fields.
+        file.manage_permission('ftw.file: Edit date fields', roles=['Contributor'], acquire=False)
+        transaction.commit()
+        browser.login().open(file, view='edit')
+        fieldsets = browser.css('fieldset')
+        self.assertEqual(
+            ['Default', 'Dates'],
             fieldsets.css('legend').text
         )

--- a/ftw/file/tests/test_advanced_edit.py
+++ b/ftw/file/tests/test_advanced_edit.py
@@ -1,56 +1,23 @@
-import transaction
-
-from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import setRoles
-from plone.testing.z2 import Browser
-from unittest2 import TestCase
-from pyquery import PyQuery
+from ftw.file.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
 
 
-class TestAdvancedEdit(TestCase):
+class TestAdvancedEdit(FunctionalTestCase):
 
-    layer = FTW_FILE_FUNCTIONAL_TESTING
-
-    def setUp(self):
-        self.browser = Browser(self.layer['app'])
-        self.browser.handleErrors = False
-
-        self.portal = self.layer['portal']
-
-        transaction.commit()
-
-    def login(self):
-        self.browser.addHeader(
-            'Authorization',
-            'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD,))
-
-    def test_no_advanced_edit(self):
-        setRoles(self.portal, TEST_USER_ID, ['Contributor', 'Editor'])
-        transaction.commit()
-        self.login()
-        self.browser.open(self.portal.absolute_url() + '/createObject?type_name=File')
-        html = PyQuery(self.browser.contents)
-        fieldsets = html('fieldset')
+    @browsing
+    def test_no_advanced_edit(self, browser):
+        self.grant('Contributor', 'Editor')
+        browser.login().open(self.portal.absolute_url() + '/createObject?type_name=File')
+        browser.css('fieldset')
+        fieldsets = browser.css('fieldset')
         self.assertEqual(len(fieldsets), 0, "We found Fieldsets. We didn't expect any'")
 
-    def test_advanced_edit(self):
-        form_tabs = ["Default",
-                     "Categorization",
-                     "Dates",
-                     "Creators",
-                     "Settings",
-                     "Ownership"
-                     ]
-        setRoles(self.portal, TEST_USER_ID, ['Contributor', 'Editor', 'Reviewer'])
-        transaction.commit()
-        self.login()
-        self.browser.open(self.portal.absolute_url() + '/createObject?type_name=File')
-        html = PyQuery(self.browser.contents)
-        fieldsets = html('fieldset')
-        self.assertEqual(len(fieldsets), 5, "We expected 5 Fieldsets got %s" % len(fieldsets))
-        legends = fieldsets('legend')
-        for legend in legends:
-            self.assertIn(legend.text, form_tabs)
+    @browsing
+    def test_advanced_edit(self, browser):
+        self.grant('Reviewer')
+        browser.login().open(self.portal.absolute_url() + '/createObject?type_name=File')
+        fieldsets = browser.css('fieldset')
+        self.assertEqual(
+            ['Default', 'Categorization', 'Dates', 'Creators', 'Settings'],
+            fieldsets.css('legend').text
+        )

--- a/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/rolemap.xml
+++ b/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/rolemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<rolemap>
+    <permissions>
+        <permission name="ftw.file: Edit date fields" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+            <role name="Reviewer"/>
+        </permission>
+    </permissions>
+</rolemap>

--- a/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/upgrade.py
+++ b/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateRolemapWithNewPermission(UpgradeStep):
+    """Update rolemap with new permission (ftw.file: Edit date fields).
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The new permission is used to protect the edit form tab (schemata) for the expiration date and effective date.

This is useful if you want to grant the permission to edit these field to a role without the need to grant "manage content settings" (which would allow the user to edit all the "advanced" fields).