### PR TITLE
Fix: Add umlaut support for MSIE filedownload

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add umlaut support for MSIE file download [busykoala]
 
 
 1.16.0 (2018-10-16)

--- a/ftw/file/fields.py
+++ b/ftw/file/fields.py
@@ -57,10 +57,10 @@ class FileField(field.FileField, ImagingMixin):
             # Other browsers need an unquoted filename
             user_agent = REQUEST.get('HTTP_USER_AGENT', '')
             if 'MSIE' in user_agent:
-                header_value = '%s; filename=%s' % (disposition,
+                header_value = '%s; filename*=UTF-8%s' % (disposition,
                                                     quote(filename))
             else:
-                header_value = '%s; filename="%s"' % (disposition, filename)
+                header_value = '%s; filename*=UTF-8"%s"' % (disposition, filename)
             RESPONSE.setHeader("Content-disposition", header_value)
 
         request_range = handleRequestRange(instance, length, REQUEST, RESPONSE)

--- a/ftw/file/tests/test_download.py
+++ b/ftw/file/tests/test_download.py
@@ -87,11 +87,11 @@ class TestFileDownload(TestCase):
     @browsing
     def test_inline_download(self, browser):
         browser.login().visit(self.context, view='@@download')
-        self.assertEquals('attachment; filename="file.doc"',
+        self.assertEquals('attachment; filename*=UTF-8"file.doc"',
                           browser.headers['content-disposition'])
 
         browser.visit(self.context, view='@@download?inline=true')
-        self.assertEquals('inline; filename="file.doc"',
+        self.assertEquals('inline; filename*=UTF-8"file.doc"',
                           browser.headers['content-disposition'])
 
     @browsing
@@ -114,7 +114,7 @@ class TestFileDownload(TestCase):
         browser.open(self.context, view='@@download/file/file.doc', method='HEAD')
         self.assertEqual('200 Ok', browser.headers['status'])
         self.assertEqual('6170', browser.headers['content-length'])
-        self.assertEqual('attachment; filename="file.doc"', browser.headers['content-disposition'])
+        self.assertEqual('attachment; filename*=UTF-8"file.doc"', browser.headers['content-disposition'])
         self.assertEqual('bytes', browser.headers['accept-ranges'])
         self.assertEqual('application/msword', browser.headers['content-type'])
 

--- a/ftw/file/tests/test_filename.py
+++ b/ftw/file/tests/test_filename.py
@@ -40,19 +40,19 @@ class TestFileName(TestCase):
     def test_whitespace(self):
         response = self.get_response_for(filename='ein file.doc')
         self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename="ein file.doc"')
+                         'attachment; filename*=UTF-8"ein file.doc"')
 
     def test_umlauts(self):
         response = self.get_response_for(
             filename='Gef\xc3\xa4hrliche Zeichen.doc')
         self.assertEqual(
             response.getHeader('Content-disposition'),
-            'attachment; filename="Gef\xc3\xa4hrliche Zeichen.doc"')
+            'attachment; filename*=UTF-8"Gef\xc3\xa4hrliche Zeichen.doc"')
 
     def test_unicode(self):
         response = self.get_response_for(filename=u'\xfcber.html')
         self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename="\xc3\xbcber.html"')
+                         'attachment; filename*=UTF-8"\xc3\xbcber.html"')
 
     def test_msie(self):
         request = HTTPRequest('', dict(HTTP_HOST='nohost:8080',
@@ -60,12 +60,12 @@ class TestFileName(TestCase):
         response = self.get_response_for(filename=u'\xfcber.html',
                                          request=request)
         self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename=%C3%BCber.html')
+                         'attachment; filename*=UTF-8%C3%BCber.html')
         response = self.get_response_for(
             filename=u'\xfcber\xe2\x80\x93uns.html', request=request)
         self.assertEqual(
             response.getHeader('Content-disposition'),
-            'attachment; filename=%C3%BCber%C3%A2%C2%80%C2%93uns.html')
+            'attachment; filename*=UTF-8%C3%BCber%C3%A2%C2%80%C2%93uns.html')
 
     def test_get_origin_filename_has_no_extension(self):
         self.set_filedata('dummyfile.txt')


### PR DESCRIPTION
The additional header payload '*=UTF-8' is solving the problem that
umlauts were displayed wrong in MSIE.

Also Tests had to be adapted since they validate the header.