### PR TITLE
Optimize disposition for most used Browsers

### DIFF
--- a/ftw/file/tests/test_download.py
+++ b/ftw/file/tests/test_download.py
@@ -87,11 +87,11 @@ class TestFileDownload(TestCase):
     @browsing
     def test_inline_download(self, browser):
         browser.login().visit(self.context, view='@@download')
-        self.assertEquals('attachment; filename*=UTF-8"file.doc"',
+        self.assertEquals('attachment; filename="file.doc"; filename=file.doc*=UTF-8',
                           browser.headers['content-disposition'])
 
         browser.visit(self.context, view='@@download?inline=true')
-        self.assertEquals('inline; filename*=UTF-8"file.doc"',
+        self.assertEquals('inline; filename="file.doc"; filename=file.doc*=UTF-8',
                           browser.headers['content-disposition'])
 
     @browsing
@@ -114,7 +114,8 @@ class TestFileDownload(TestCase):
         browser.open(self.context, view='@@download/file/file.doc', method='HEAD')
         self.assertEqual('200 Ok', browser.headers['status'])
         self.assertEqual('6170', browser.headers['content-length'])
-        self.assertEqual('attachment; filename*=UTF-8"file.doc"', browser.headers['content-disposition'])
+        self.assertEqual('attachment; filename="file.doc"; filename=file.doc*=UTF-8',
+                         browser.headers['content-disposition'])
         self.assertEqual('bytes', browser.headers['accept-ranges'])
         self.assertEqual('application/msword', browser.headers['content-type'])
 

--- a/ftw/file/tests/test_filename.py
+++ b/ftw/file/tests/test_filename.py
@@ -39,33 +39,35 @@ class TestFileName(TestCase):
 
     def test_whitespace(self):
         response = self.get_response_for(filename='ein file.doc')
-        self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename*=UTF-8"ein file.doc"')
+        self.assertEqual('attachment; filename="ein file.doc"; filename=ein file.doc*=UTF-8',
+                         response.getHeader('Content-disposition'))
 
     def test_umlauts(self):
         response = self.get_response_for(
             filename='Gef\xc3\xa4hrliche Zeichen.doc')
         self.assertEqual(
-            response.getHeader('Content-disposition'),
-            'attachment; filename*=UTF-8"Gef\xc3\xa4hrliche Zeichen.doc"')
+            'attachment; filename="Gef\xc3\xa4hrliche Zeichen.doc"; filename=Gef\xc3\xa4hrliche Zeichen.doc*=UTF-8',
+            response.getHeader('Content-disposition'))
 
     def test_unicode(self):
         response = self.get_response_for(filename=u'\xfcber.html')
-        self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename*=UTF-8"\xc3\xbcber.html"')
+        self.assertEqual(
+            'attachment; filename="\xc3\xbcber.html"; filename=\xc3\xbcber.html*=UTF-8',
+            response.getHeader('Content-disposition'))
 
     def test_msie(self):
         request = HTTPRequest('', dict(HTTP_HOST='nohost:8080',
                                        HTTP_USER_AGENT='MSIE'), {})
         response = self.get_response_for(filename=u'\xfcber.html',
                                          request=request)
-        self.assertEqual(response.getHeader('Content-disposition'),
-                         'attachment; filename*=UTF-8%C3%BCber.html')
+
+        self.assertEqual('attachment; filename=\xc3\xbcber.html; filename*=UTF-8\'\'%C3%BCber.html',
+                         response.getHeader('Content-disposition'))
         response = self.get_response_for(
             filename=u'\xfcber\xe2\x80\x93uns.html', request=request)
         self.assertEqual(
-            response.getHeader('Content-disposition'),
-            'attachment; filename*=UTF-8%C3%BCber%C3%A2%C2%80%C2%93uns.html')
+            'attachment; filename=\xc3\xbcber\xc3\xa2\xc2\x80\xc2\x93uns.html; filename*=UTF-8\'\'%C3%BCber%C3%A2%C2%80%C2%93uns.html',
+            response.getHeader('Content-disposition'))
 
     def test_get_origin_filename_has_no_extension(self):
         self.set_filedata('dummyfile.txt')


### PR DESCRIPTION
Fixes the side-effects introduced in https://github.com/4teamwork/ftw.file/pull/76

IE and Edge require a different disposition than Chrome, Firefox and Safari
so we need to differ them. I implemented that by checking the user agent content
for keywords suggesting that the user downloads with MSIE or Edge.

It is possible that the keywords do not match all the possible user_agent cases. Since
there is an infinite number of possible user agents. I think covering the most common
cases is perfectly fine.

I tested that the filenames having umlauts and empty space (`ÖsFüülç$.docx` and `Ös Fü ülç$.docx`) in the browsers:
- Chrome (73.0.3683.103)
- Firefox (66.0.5)
- Safari (12.0.3)
- Internet Explorer (11.648.17134.0)
- Edge (42.17134.1.0)