### PR TITLE
Fix FTI name to be the same as its ID.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix incorrect ID in FTI definition. [jone]
 
 
 2.0.1 (2019-11-04)

--- a/ftw/file/profiles/default/types/ftw.file.File.xml
+++ b/ftw/file/profiles/default/types/ftw.file.File.xml
@@ -2,7 +2,7 @@
 <object
     i18n:domain="plone"
     meta_type="Dexterity FTI"
-    name="ftw.file"
+    name="ftw.file.File"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Basic properties -->

--- a/ftw/file/upgrades/20191003173301_archetypes_to_dexterity/types/ftw.file.File.xml
+++ b/ftw/file/upgrades/20191003173301_archetypes_to_dexterity/types/ftw.file.File.xml
@@ -2,7 +2,7 @@
 <object
     i18n:domain="plone"
     meta_type="Dexterity FTI"
-    name="ftw.file"
+    name="ftw.file.File"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Basic properties -->

--- a/ftw/file/upgrades/20191101165228_fix_fti/types/ftw.file.File.xml
+++ b/ftw/file/upgrades/20191101165228_fix_fti/types/ftw.file.File.xml
@@ -2,7 +2,7 @@
 <object
     i18n:domain="plone"
     meta_type="Dexterity FTI"
-    name="ftw.file"
+    name="ftw.file.File"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
     <property name="factory">ftw.file.File</property>


### PR DESCRIPTION
The ID (=filename) and the name of the FTI should be the same (convention).  This fixes the wrong name. AFAIK there is no visible negative impact thus no migration is required.