### PR TITLE
Dexterity migration: import GS profile even when not migrating

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix incorrect ID in FTI definition. [jone]
+- Dexterity migration: import GS profile even when not migrating content. [jone]
 
 
 2.0.1 (2019-11-04)

--- a/ftw/file/upgrades/20191003173301_archetypes_to_dexterity/upgrade.py
+++ b/ftw/file/upgrades/20191003173301_archetypes_to_dexterity/upgrade.py
@@ -8,7 +8,7 @@ class MigrateToDexterity(UpgradeStep, ATToDXMixin):
     """
 
     def __call__(self):
+        self.install_upgrade_profile()
         if os.environ.get('FTW_FILE_SKIP_DEXTERITY_MIGRATION', '').lower() == 'true':
             return
-        self.install_upgrade_profile()
         self.install_ftw_file_dx_migration()


### PR DESCRIPTION
When an environment variable is set while running the AT to DX migration upgrade step, the content migration itself is not executed. This makes it possible for a policy package to control in what order which types are migrated.

The existing upgrade step is changed so that it imports the generic setup profile even when the skip-migration-env variable is activated.

 Before all generic setup changes had to be copied to the policy package, but we want to be able to only install the configuration changes and migrate later without duplicating the settings.