### PR TITLE
DX migration: ignore flowplayer fields (width and height).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- DX migration: ignore flowplayer fields (``width`` and ``height``). [jone]
 
 
 2.0.2 (2019-11-05)

--- a/ftw/file/upgrades/__init__.py
+++ b/ftw/file/upgrades/__init__.py
@@ -68,7 +68,13 @@ class ATToDXMixin(object):
 
         migrator = InplaceMigrator(
             new_portal_type='ftw.file.File',
-            ignore_fields=('excludeFromNav', 'lastModifier', 'topics',),
+            ignore_fields=(
+                'excludeFromNav',
+                'lastModifier',
+                'topics',
+                'height',  # flowplayer
+                'width',  # flowplayer
+            ),
             field_mapping={
                 'documentDate': 'document_date',
                 'originFilename': 'filename_override',


### PR DESCRIPTION
These fields may appear dynamically when the file is a movie and flowplayer is used.