### PR TITLE
Fix contentType attribute type. It needs to be utf-8 ...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Add a FileUpload adaptor for plone.namedfile so that ftw.file uploads can
   work in ftw.simplelayout's FileListingBlock. [djowett-ftw]
+- Fix contentType attribute type. It needs to be utf-8 for the zope.schema.BytesLine. [mathias.leimgruber]
 
 
 2.1.0 (2019-11-12)

--- a/ftw/file/content/dxfile.py
+++ b/ftw/file/content/dxfile.py
@@ -41,6 +41,11 @@ class BlobImageValueType(NamedBlobImage):
             if mimetypeitem:
                 contentType = mimetypeitem.normalized()
 
+        # contentType (a zope.schema.BytesLine) requires utf-8,
+        # but Products.MimetypesRegistry <= 2.0.8 returns unicode rather than utf-8
+        if isinstance(contentType, unicode):
+            contentType = contentType.encode('utf8')
+
         super(BlobImageValueType, self).__init__(data, contentType, filename)
 
 


### PR DESCRIPTION
... for the zope.schema.BytesLine


This way we can support plone versions, before 4.3.10

Part of the solution to https://github.com/4teamwork/izug.organisation/issues/1620
