### PR TITLE
Add a FileUpload adaptor for plone.namedfile

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a FileUpload adaptor for plone.namedfile so that ftw.file uploads can
+  work in ftw.simplelayout's FileListingBlock. [djowett-ftw]
 
 
 2.1.0 (2019-11-12)

--- a/ftw/file/configure.zcml
+++ b/ftw/file/configure.zcml
@@ -74,4 +74,12 @@
       handler=".handlers.handle_protected_file"
      />
 
+  <!-- Backported from Plone 5's version of p.a.z3cform -->
+  <utility
+    zcml:condition="not-have plone-5"
+    name="ZPublisher.HTTPRequest.FileUpload"
+    provides="plone.namedfile.interfaces.IStorage"
+    factory=".factories.Zope2FileUploadStorable"
+  />
+
 </configure>

--- a/ftw/file/factories.py
+++ b/ftw/file/factories.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from zope.interface import implementer
+from plone.namedfile.storages import MAXCHUNKSIZE
+from plone.namedfile.interfaces import IStorage
+
+# Copied from plone.app.z3form 3.1.0
+@implementer(IStorage)
+class Zope2FileUploadStorable(object):
+
+    def store(self, data, blob):
+        data.seek(0)
+        with blob.open('w') as fp:
+            block = data.read(MAXCHUNKSIZE)
+            while block:
+                fp.write(block)
+                block = data.read(MAXCHUNKSIZE)


### PR DESCRIPTION
   so that ftw.file uploads can work in ftw.simplelayout's FileListingBlock.
   Part of resolution for https://github.com/4teamwork/izug.organisation/issues/1620