### PR TITLE
Fix upgrade steps that wouldn't run in 2.x codebase

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix upgrade steps that wouldn't run in 2.x codebase. [djowett-ftw]
 
 
 2.2.1 (2019-11-25)

--- a/ftw/file/upgrades/20160601223722_set_empty_document_date/upgrade.py
+++ b/ftw/file/upgrades/20160601223722_set_empty_document_date/upgrade.py
@@ -10,9 +10,9 @@ class SetEmptyDocumentDate(UpgradeStep):
         query = {'object_provides': 'ftw.file.interfaces.IFile'}
         for obj in self.objects(query, 'Update empty documentDate'):
 
-            if obj.getDocumentDate():
+            if obj.Schema()['documentDate'].get(obj):
                 # We skip files with a documentdate
                 continue
 
-            obj.setDocumentDate(obj.created())
+            obj.Schema()['documentDate'].set(obj, obj.created())
             obj.reindexObject(idxs=['documentDate'])

--- a/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/upgrade.py
+++ b/ftw/file/upgrades/20180830120830_update_rolemap_with_new_permission/upgrade.py
@@ -6,4 +6,6 @@ class UpdateRolemapWithNewPermission(UpgradeStep):
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
+        # Permission referred to in rolemap.xml no longer exists
+        # self.install_upgrade_profile()
+        pass


### PR DESCRIPTION
2 old AT upgrade steps wouldn't run as is in the 2.x code. So we:

1. Skipped the permission update where the permission is no longer in 2.x code
2. where getDocumentDate was not found for some reason, we coded it differently in the upgrade for that field.