### PR TITLE
Fix deleting Plone site.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix deleting Plone site. [jone]
 
 
 2.2.2 (2019-11-26)

--- a/ftw/file/handlers.py
+++ b/ftw/file/handlers.py
@@ -1,10 +1,15 @@
 from ftw.file import fileMessageFactory as _
 from plone import api
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.CMFPlone.utils import safe_unicode
 from zope.i18n import translate
 
 
 def handle_protected_file(obj, event):
+    if IPloneSiteRoot.providedBy(event.object):
+        # The Plone site is beeing deleted.
+        return
+
     if obj.is_protected:
         api.portal.show_message(
             message=translate(

--- a/ftw/file/handlers.py
+++ b/ftw/file/handlers.py
@@ -7,7 +7,7 @@ from zope.i18n import translate
 
 def handle_protected_file(obj, event):
     if IPloneSiteRoot.providedBy(event.object):
-        # The Plone site is beeing deleted.
+        # The Plone site is being deleted.
         return
 
     if obj.is_protected:


### PR DESCRIPTION
When the Plone site is deleted, we do not want to check for protected files. This fixes deleting the Plone site when ftw.file is installed.