### PR TITLE
Override content_type method to fix mimetype metadata.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Override content_type method to fix mime_type metadata. [tinagerber]
 
 
 2.2.5 (2020-01-09)

--- a/ftw/file/content/dxfile.py
+++ b/ftw/file/content/dxfile.py
@@ -167,3 +167,6 @@ class File(Item):
 
     def getContentType(self):
         return getattr(self.file, 'contentType', 'application/octet-stream')
+
+    def content_type(self):
+        return self.getContentType()

--- a/ftw/file/upgrades/20200120172522_update_mime_type_metadata/upgrade.py
+++ b/ftw/file/upgrades/20200120172522_update_mime_type_metadata/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateMimeTypeMetadata(UpgradeStep):
+    """Update mime type metadata.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'object_provides': 'ftw.file.interfaces.IFile'}
+        for obj in self.objects(query, 'Update mime_type'):
+            obj.reindexObject(idxs=['getId'])  # update metadata


### PR DESCRIPTION
closes https://github.com/4teamwork/izug.organisation/issues/1806