### PR TITLE
Fix file redirect view for plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
+- Quote URL (including filename) also in file redirect view. [mathias.leimgruber]
+
 - Use z2 Server to be closer to the real world in tests. [mathias.leimgruber]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use z2 Server to be closer to the real world in tests. [mathias.leimgruber]
 
 
 2.3.0 (2020-01-23)

--- a/ftw/file/browser/download.py
+++ b/ftw/file/browser/download.py
@@ -121,7 +121,7 @@ class FileViewRedirector(BrowserView):
     def __call__(self):
         response = self.request.RESPONSE
         current_url = self.context.absolute_url()
-        filename = self.context.file.filename
+        filename = get_optimized_filename(self.context.file.filename)
         if redirect_to_download_by_default(self.context):
             return response.redirect(
                 current_url + '/@@download/file/' + filename)

--- a/ftw/file/testing.py
+++ b/ftw/file/testing.py
@@ -6,6 +6,7 @@ from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.testing import z2
 from zope.configuration import xmlconfig
 import ftw.file.tests.builders  # noqa
 
@@ -18,7 +19,7 @@ def functional_session_factory():
 
 class FtwFileLayer(PloneSandboxLayer):
 
-    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
+    defaultBases = (z2.ZSERVER_FIXTURE, COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         xmlconfig.string(

--- a/ftw/file/tests/test_download.py
+++ b/ftw/file/tests/test_download.py
@@ -3,7 +3,7 @@ from ftw.builder import create
 from ftw.file.interfaces import IFileDownloadedEvent
 from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from ftw.testbrowser import LIB_TRAVERSAL
+from ftw.testbrowser import LIB_REQUESTS
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedBlobFile
@@ -20,6 +20,7 @@ class TestFileDownload(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
         self.file = NamedBlobFile(data=1234 * 'dummy',
@@ -93,7 +94,7 @@ class TestFileDownload(TestCase):
 
     @browsing
     def test_head_request(self, browser):
-        browser.default_driver = LIB_TRAVERSAL
+        browser.default_driver = LIB_REQUESTS
 
         browser.login()
 
@@ -103,7 +104,7 @@ class TestFileDownload(TestCase):
         browser.open(self.context, view='@@download', method='HEAD')
         self.assertEqual(200, browser.status_code)
         self.assertEqual(
-            'http://nohost/plone/file.doc/@@download/file/file.doc',
+            '{}/file.doc/@@download/file/file.doc'.format(self.portal_url),
             browser.url
         )
 

--- a/ftw/file/tests/test_download_redirection.py
+++ b/ftw/file/tests/test_download_redirection.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.file.testing import FTW_FILE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_PASSWORD
@@ -18,6 +17,7 @@ class TestDownloadRedirection(TestCase):
 
     def setUp(self):
         portal = self.layer['portal']
+        self.portal_url = portal.absolute_url()
         acl_users = getToolByName(portal, 'acl_users')
         acl_users.userFolderAddUser('reader', TEST_USER_PASSWORD,
                                     ['Reader'], [])
@@ -28,14 +28,14 @@ class TestDownloadRedirection(TestCase):
     def test_redirects_to_details_view_when_i_can_edit(self, browser):
         obj = create(Builder('file').with_dummy_content())
         browser.login('contributor').visit(obj)
-        self.assertEquals('http://nohost/plone/test.doc/view', browser.url)
+        self.assertEquals('{}/test.doc/view'.format(self.portal_url), browser.url)
 
     @browsing
     def test_redirects_to_download_when_i_cannot_edit(self, browser):
         obj = create(Builder('file').with_dummy_content())
         browser.visit(obj)
         self.assertEquals(
-            'http://nohost/plone/test.doc/@@download/file/test.doc',
+            '{}/test.doc/@@download/file/test.doc'.format(self.portal_url),
             browser.url)
 
     @browsing
@@ -48,13 +48,13 @@ class TestDownloadRedirection(TestCase):
         # Redirect users having the permission to edit file.
         browser.login('contributor').visit(obj)
 
-        self.assertEquals('http://nohost/plone/test.doc/view',
+        self.assertEquals('{}/test.doc/view'.format(self.portal_url),
                           browser.url)
 
         # Redirect users not having the permission to edit file.
         browser.login('reader').visit(obj)
 
-        self.assertEquals('http://nohost/plone/test.doc/view',
+        self.assertEquals('{}/test.doc/view'.format(self.portal_url),
                           browser.url)
 
 
@@ -64,6 +64,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
 
     def setUp(self):
         portal = self.layer['portal']
+        self.portal_url = portal.absolute_url()
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
     @browsing
@@ -75,7 +76,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
         browser.login().visit(obj, view='@@download')
 
         self.assertEquals(
-            'http://nohost/plone/doc.pdf/@@download/file/doc.pdf',
+            '{}/doc.pdf/@@download/file/doc.pdf'.format(self.portal_url),
             browser.url)
 
         self.assertEquals('PDF CONTENT', browser.contents)
@@ -89,7 +90,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
         browser.login().visit(obj, view='download')
 
         self.assertEquals(
-            'http://nohost/plone/doc.pdf/@@download/file/doc.pdf',
+            '{}/doc.pdf/@@download/file/doc.pdf'.format(self.portal_url),
             browser.url)
 
         self.assertEquals('PDF CONTENT', browser.contents)
@@ -106,8 +107,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
         browser.login().visit(obj, view='download')
 
         self.assertEquals(
-            'http://nohost/plone/worter-bilder.pdf/@@download/' +
-            'file/w%C3%B6rter%20%26%20bilder.pdf',
+            '{}/worter-bilder.pdf/@@download/file/w%C3%B6rter%20%26%20bilder.pdf'.format(self.portal_url),
             browser.url)
 
         self.assertEquals('PDF CONTENT', browser.contents)
@@ -124,8 +124,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
         browser.login().visit(obj, view='download')
 
         self.assertEquals(
-            'http://nohost/plone/worter-bilder.pdf/@@download/' +
-            'file/w%C3%B6rter%20%26%20bilder.pdf',
+            '{}/worter-bilder.pdf/@@download/file/w%C3%B6rter%20%26%20bilder.pdf'.format(self.portal_url),
             browser.url)
 
         self.assertEquals('PDF CONTENT', browser.contents)
@@ -142,8 +141,7 @@ class TestDownloadRedirectToURLWithFilename(TestCase):
         browser.login().visit(obj, view='download')
 
         self.assertEquals(
-            'http://nohost/plone/50-to80.pdf/@@download/' +
-            'file/50to80.pdf',
+            '{}/50-to80.pdf/@@download/file/50to80.pdf'.format(self.portal_url),
             browser.url)
 
         self.assertEquals('PDF CONTENT', browser.contents)

--- a/ftw/file/tests/test_outputfilter.py
+++ b/ftw/file/tests/test_outputfilter.py
@@ -29,7 +29,7 @@ class TestOutputfilter(TestCase):
                 scale_uid = scale
 
         image = page.css('.fileListing img').first
-        url = "http://nohost/plone/testimage.jpg/@@images/"
+        url = "{}/testimage.jpg/@@images/".format(self.layer['portal'].absolute_url())
         self.assertEqual(
             url + scale_uid + ".jpeg",
             image.attrib['src'])

--- a/ftw/file/tests/test_overlay.py
+++ b/ftw/file/tests/test_overlay.py
@@ -13,6 +13,7 @@ class TestFileOverlay(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
         self.context = create(Builder('file')
@@ -24,10 +25,11 @@ class TestFileOverlay(TestCase):
         browser.login().visit(self.context)
         self.assertIn(
             '<a id="preview" class="colorboxLink"'
-            ' href="http://nohost/plone/transparent.gif/@@images/file">',
+            ' href="{}/transparent.gif/@@images/file">'.format(self.portal_url),
             browser.contents)
-        self.assertIn('<img src="http://nohost/plone/transparent.gif/@@images',
-                      browser.contents)
+        self.assertIn(
+            '<img src="{}/transparent.gif/@@images'.format(self.portal_url),
+            browser.contents)
 
     @browsing
     def test_image_link_works(self, browser):

--- a/ftw/file/tests/test_utils.py
+++ b/ftw/file/tests/test_utils.py
@@ -91,6 +91,7 @@ class FileMetadataBase(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.portal_url = self.portal.absolute_url()
         self.request = self.layer['request']
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         self.dummyfile = create(Builder('file')
@@ -164,7 +165,7 @@ class TestFileMetadataAuthor(FileMetadataBase):
         self.assertEqual(
             {'id': 'chuck',
              'name': 'Chuck Norris',
-             'url': 'http://nohost/plone/author/chuck'},
+             'url': '{}/author/chuck'.format(self.portal_url)},
             FileMetadata(self.dummyfile).author)
 
     def test_return_userid_and_url_if_user_exists_without_fullname(self):
@@ -178,7 +179,7 @@ class TestFileMetadataAuthor(FileMetadataBase):
         self.assertEqual(
             {'id': 'chuck',
              'name': 'chuck',
-             'url': 'http://nohost/plone/author/chuck'},
+             'url': '{}/author/chuck'.format(self.portal_url)},
             FileMetadata(self.dummyfile).author)
 
     def test_return_userid_and_no_url_if_user_does_not_exist(self):


### PR DESCRIPTION
Problem:
The redirect view did no quote the URL, which leads to a problem setting the location header in plone 5 if the filename contains a Umlaut.

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 170: ordinal not in range(128)
  File "ZPublisher/Publish.py", line 138, in publish
    request, bind=1)
  File "ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "home/zope/eggs/ftw.file-2.2.6-py2.7.egg/ftw/file/browser/download.py", line 127, in __call__
    current_url + '/@@download/file/' + filename)
  File "ZPublisher/HTTPResponse.py", line 609, in redirect
    self.setHeader('Location', location)
  File "ZPublisher/HTTPResponse.py", line 331, in setHeader
    name, value = _scrubHeader(name, value)
  File "ZPublisher/HTTPResponse.py", line 134, in _scrubHeader
    return ''.join(_CRLF.split(str(name))), ''.join(_CRLF.split(str(value)))
```

In plone 4 the issue is not there since ZPublisher does not scrub the header values.


We did not recognise this issue in tests, since the LIB_MECHANIZE driver does not follow redirects. Thus I changed that for 2 tests, in order to have a more real browser behavior.

for the requests implementation of test browser we need to actually bind a port, so I changed all tests using a ZServer. This also brings us a bit closer to the real world. 