### PR TITLE
Fix filepath used for filename when uploading through microsoft edge

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix saving file with whole windows file path as filename when uploading through Microsoft Edge [Nachtalb]
 
 
 2.4.0 (2020-09-03)

--- a/ftw/file/browser/upload.py
+++ b/ftw/file/browser/upload.py
@@ -5,6 +5,7 @@ from plone import api
 from zExceptions import BadRequest
 from zope.i18n import translate
 from zope.publisher.browser import BrowserView
+import ntpath
 import json
 
 
@@ -18,6 +19,11 @@ class FileUpload(BrowserView):
 
         old_filename = safe_unicode(self.context.file.filename)
         new_filename = safe_unicode(self.file.filename)
+
+        if ntpath.basename(new_filename) != new_filename:
+            # Windows Edge uploads files with the filename being the whole
+            # Path on the windows system. Get the basename instead.
+            new_filename = ntpath.basename(new_filename)
 
         change_note = translate(
             _(u'File "{}" replaced with "{}" via drag & drop.'.format(


### PR DESCRIPTION
When uploading files by Drag'n'Drop through Microsoft Edge 44.17763.1.0 the filename was set to the whole path on the original system. Here you can see the change in filename before and after the fix: 
![image](https://user-images.githubusercontent.com/9467802/92456136-d48a3c00-f1c2-11ea-9cd9-e3e5eb4c5267.png)
