### PR TITLE
Add missing dexterity file documentDate indexer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add missing documentDate indexer for dexterity file [Nachtalb]
 
 
 2.4.1 (2020-09-09)

--- a/ftw/file/configure.zcml
+++ b/ftw/file/configure.zcml
@@ -95,4 +95,10 @@
       handler=".handlers.handle_protected_file"
      />
 
+  <!-- indexer -->
+  <adapter
+      name="documentDate"
+      factory=".indexer.document_date"
+      />
+
 </configure>

--- a/ftw/file/indexer.py
+++ b/ftw/file/indexer.py
@@ -1,0 +1,9 @@
+from plone.indexer.decorator import indexer
+from Products.CMFPlone.utils import safe_hasattr
+from zope.interface import Interface
+
+
+@indexer(Interface)
+def document_date(obj):
+    if safe_hasattr(obj, 'document_date'):
+        return obj.document_date


### PR DESCRIPTION
Previously on AT files it was automatically indexted because the field had the same name ("documentDate"). In the dexterity version of ftw.file the field is called "document_date" instead and thus is not automatically indexed.