### PR TITLE
Fix scale generation of DX Images in TinyMCE

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix scale generation of DX Images in TinyMCE [Nachtalb]
 
 
 2.4.2 (2020-09-16)

--- a/ftw/file/custom_outputfilter.py
+++ b/ftw/file/custom_outputfilter.py
@@ -1,5 +1,6 @@
-from plone.outputfilters.filters import resolveuid_and_caption
+from ftw.file.interfaces import IFile
 from plone.app.imaging.interfaces import IImageScale
+from plone.outputfilters.filters import resolveuid_and_caption
 
 
 class FtwFileFilter(resolveuid_and_caption.ResolveUIDAndCaptionFilter):
@@ -7,6 +8,10 @@ class FtwFileFilter(resolveuid_and_caption.ResolveUIDAndCaptionFilter):
     def resolve_image(self, src):
         (image, fullimage, source, description) = resolveuid_and_caption.\
             ResolveUIDAndCaptionFilter.resolve_image(self, src)
+
+        if not IFile.providedBy(fullimage):
+            return image, fullimage, source, description
+
         if not IImageScale.providedBy(image):
             url = ''
             obj, subpath, appendix = self.resolve_link(src)


### PR DESCRIPTION
Scales of dexterity images do not provide `IImageScale` anymore and thus the custom output filter does stuff which it should not. Because this output filter is only meant for ftw.file.Files in the first place we now also check for that and do not process anything if it's not a ftw.file.File. 