### PR TITLE
Fix comma in filename results in corrupt content-disposition

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix comma in filename generates corrupt content-disposition
+  (correctly implement rfc6266) [Nachtalb]
 
 
 2.4.3 (2020-10-08)

--- a/ftw/file/browser/download.py
+++ b/ftw/file/browser/download.py
@@ -95,18 +95,8 @@ class Download(NameFileDownload):
         else:
             disposition = 'attachment'
 
-        # Microsoft browsers disposition has to be formatted differently
-        disposition_default = '{}; filename="{}"; filename={}*=UTF-8'.format(
-            disposition, self.filename, self.filename)
-        disposition_microsoft = '{}; filename={}; filename*=UTF-8\'\'{}'.format(
+        disposition = '{}; filename="{}"; filename*=UTF-8\'\'{}'.format(
             disposition, self.filename, urllib.quote(self.filename))
-        # use disposition_default by default
-        disposition = disposition_default
-
-        if any(key in user_agent for key in ['MSIE', 'WOW64', 'Edge']):
-            # Set different dispositon if the user_agent
-            # indicates download by a microsoft browser
-            disposition = disposition_microsoft
 
         self.request.response.setHeader("Content-disposition", disposition)
 

--- a/ftw/file/tests/test_download.py
+++ b/ftw/file/tests/test_download.py
@@ -86,11 +86,11 @@ class TestFileDownload(TestCase):
     @browsing
     def test_inline_download(self, browser):
         browser.login().visit(self.context, view='@@download')
-        self.assertEquals('attachment; filename="file.doc"; filename=file.doc*=UTF-8',
+        self.assertEquals('attachment; filename="file.doc"; filename*=UTF-8\'\'file.doc',
                           browser.headers['content-disposition'])
 
         browser.open(self.context.absolute_url() + '/@@download?inline=true')
-        self.assertEquals('inline; filename="file.doc"; filename=file.doc*=UTF-8',
+        self.assertEquals('inline; filename="file.doc"; filename*=UTF-8\'\'file.doc',
                           browser.headers['content-disposition'])
 
     @browsing
@@ -113,7 +113,7 @@ class TestFileDownload(TestCase):
         browser.open(self.context, view='@@download/file/file.doc', method='HEAD')
         self.assertEqual('200 Ok', browser.headers['status'])
         self.assertEqual('6170', browser.headers['content-length'])
-        self.assertEqual('attachment; filename="file.doc"; filename=file.doc*=UTF-8',
+        self.assertEqual('attachment; filename="file.doc"; filename*=UTF-8\'\'file.doc',
                          browser.headers['content-disposition'])
         self.assertEqual('bytes', browser.headers['accept-ranges'])
         self.assertEqual('application/msword', browser.headers['content-type'])

--- a/ftw/file/tests/test_filename.py
+++ b/ftw/file/tests/test_filename.py
@@ -40,33 +40,19 @@ class TestFileName(TestCase):
 
     def test_whitespace(self):
         response = self.get_response_for(filename='ein file.doc')
-        self.assertEqual('attachment; filename="ein file.doc"; filename=ein file.doc*=UTF-8',
+        self.assertEqual('attachment; filename="ein file.doc"; filename*=UTF-8\'\'ein%20file.doc',
                          response.getHeader('Content-disposition'))
 
     def test_umlauts(self):
         response = self.get_response_for(filename='Gef\xc3\xa4hrliche Zeichen.doc')
         self.assertEqual(
-            'attachment; filename="Gef\xc3\xa4hrliche Zeichen.doc"; filename=Gef\xc3\xa4hrliche Zeichen.doc*=UTF-8',
+            'attachment; filename="Gef\xc3\xa4hrliche Zeichen.doc"; filename*=UTF-8\'\'Gef%C3%A4hrliche%20Zeichen.doc',
             response.getHeader('Content-disposition'))
 
     def test_unicode(self):
         response = self.get_response_for(filename=u'\xfcber.html')
         self.assertEqual(
-            'attachment; filename="\xc3\xbcber.html"; filename=\xc3\xbcber.html*=UTF-8',
-            response.getHeader('Content-disposition'))
-
-    def test_msie(self):
-        request = self.context.REQUEST
-        request.set('HTTP_USER_AGENT', 'MSIE')
-        response = self.get_response_for(filename=u'\xfcber.html',
-                                         request=request)
-
-        self.assertEqual('attachment; filename=\xc3\xbcber.html; filename*=UTF-8\'\'%C3%BCber.html',
-                         response.getHeader('Content-disposition'))
-        response = self.get_response_for(
-            filename=u'\xfcber\xe2\x80\x93uns.html', request=request)
-        self.assertEqual(
-            'attachment; filename=\xc3\xbcber\xc3\xa2\xc2\x80\xc2\x93uns.html; filename*=UTF-8\'\'%C3%BCber%C3%A2%C2%80%C2%93uns.html',
+            'attachment; filename="\xc3\xbcber.html"; filename*=UTF-8\'\'%C3%BCber.html',
             response.getHeader('Content-disposition'))
 
     def test_get_filename_override_has_no_extension(self):


### PR DESCRIPTION
For some reason, we did not follow rfc6266 for non-microsoft browsers.
The implementation we had for Microsoft browsers was the correct rfc6266
way and thus we use it as default now. See: https://tools.ietf.org/html/rfc6266#section-5

https://extranet.4teamwork.ch/support/basel-landschaft/tracker/189/