### PR TITLE
Feature: Restrict mimetypes allowed to use with ftw.file.File.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Feature: Restrict mimetypes allowed to use with ftw.file.File. [mathias.leimgruber]
 
 
 2.4.4 (2020-10-12)

--- a/ftw/file/profiles/default/registry.xml
+++ b/ftw/file/profiles/default/registry.xml
@@ -19,4 +19,12 @@
         <value>False</value>
     </record>
 
+    <record name="ftw.file.filesettings.invalid_mimeteypes">
+        <field type="plone.registry.field.List">
+            <title>Invalid mime types</title>
+            <description>Files with those mime types get rejected</description>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+    </record>
+
 </registry>

--- a/ftw/file/profiles/default_plone5/registry.xml
+++ b/ftw/file/profiles/default_plone5/registry.xml
@@ -31,4 +31,12 @@
         <value>False</value>
     </record>
 
+    <record name="ftw.file.filesettings.invalid_mimeteypes">
+        <field type="plone.registry.field.List">
+            <title>Invalid mime types</title>
+            <description>Files with those mime types get rejected</description>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+    </record>
+
 </registry>

--- a/ftw/file/profiles/uninstall/registry.xml
+++ b/ftw/file/profiles/uninstall/registry.xml
@@ -3,5 +3,6 @@
 
     <record name="ftw.file.filesettings.user_ids" remove="True" />
     <record name="ftw.file.disable_download_redirect" remove="True" />
+    <record name="ftw.file.filesettings.invalid_mimeteypes" remove="True" />
 
 </registry>

--- a/ftw/file/profiles/uninstall_plone5/registry.xml
+++ b/ftw/file/profiles/uninstall_plone5/registry.xml
@@ -4,5 +4,6 @@
     <records prefix="plone.bundles/ftw-file-resources" interface="Products.CMFPlone.interfaces.IBundleRegistry" remove="True"/>
     <record name="ftw.file.filesettings.user_ids" remove="True" />
     <record name="ftw.file.disable_download_redirect" remove="True" />
+    <record name="ftw.file.filesettings.invalid_mimeteypes" remove="True" />
 
 </registry>

--- a/ftw/file/tests/test_invalid_mimetypes.py
+++ b/ftw/file/tests/test_invalid_mimetypes.py
@@ -1,0 +1,26 @@
+from ftw.builder import create, Builder
+from ftw.file.tests import FunctionalTestCase
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+
+class TestInvalidMimeTypes(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestInvalidMimeTypes, self).setUp()
+        self.grant('Manager')
+
+        self.registry = getUtility(IRegistry)
+
+    def test_do_not_create_files_with_invalid_mimetype(self):
+        obj = create(Builder('file')
+                     .titled(u'Some title')
+                     .attach_asset(u'test.pdf'))
+
+        self.assertIn(obj.getId(), self.portal)
+
+        self.registry['ftw.file.filesettings.invalid_mimeteypes'] = [u'application/pdf', ]
+        with self.assertRaises(ValueError):
+            create(Builder('file')
+                   .titled(u'Some title')
+                   .attach_asset(u'test.pdf'))

--- a/ftw/file/upgrades/20201105080517_add_invalid_mimetypes_registry_entry/registry.xml
+++ b/ftw/file/upgrades/20201105080517_add_invalid_mimetypes_registry_entry/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry>
+
+    <record name="ftw.file.filesettings.invalid_mimeteypes">
+        <field type="plone.registry.field.List">
+            <title>Invalid mime types</title>
+            <description>Files with those mime types get rejected</description>
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
+    </record>
+
+</registry>

--- a/ftw/file/upgrades/20201105080517_add_invalid_mimetypes_registry_entry/upgrade.py
+++ b/ftw/file/upgrades/20201105080517_add_invalid_mimetypes_registry_entry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddInvalidMimetypesRegistryEntry(UpgradeStep):
+    """Add invalid_mimetypes registry entry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
You can configure globally a list of invalid mimetypes.
The system so far just throws a ValueError if violated. 

Next PR.
- Add form validation