### PR TITLE
Raise Invalid from zope.interface in order to have a meaningful error meassge in z3c.form.

### DIFF
--- a/ftw/file/content/dxfile.py
+++ b/ftw/file/content/dxfile.py
@@ -33,7 +33,7 @@ def validate_mime_type(data, contentType, filename):
     registry = getUtility(IRegistry)
     invalid_mimetypes = registry['ftw.file.filesettings.invalid_mimeteypes']
     if invalid_mimetypes and contentType in invalid_mimetypes:
-        raise ValueError('Invalid mime type: {} is not allowed'.format(contentType))
+        raise Invalid('Invalid mime type: {} is not allowed'.format(contentType))
 
 
 class BlobImageValueType(NamedBlobImage):

--- a/ftw/file/tests/test_invalid_mimetypes.py
+++ b/ftw/file/tests/test_invalid_mimetypes.py
@@ -1,7 +1,12 @@
 from ftw.builder import create, Builder
 from ftw.file.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+from zope.interface import Invalid
+import os
+import transaction
 
 
 class TestInvalidMimeTypes(FunctionalTestCase):
@@ -20,7 +25,37 @@ class TestInvalidMimeTypes(FunctionalTestCase):
         self.assertIn(obj.getId(), self.portal)
 
         self.registry['ftw.file.filesettings.invalid_mimeteypes'] = [u'application/pdf', ]
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Invalid):
             create(Builder('file')
                    .titled(u'Some title')
                    .attach_asset(u'test.pdf'))
+
+    @browsing
+    def test_show_meaningful_message_on_form(self, browser):
+        file_path = '{}/assets/test.pdf'.format(os.path.split(__file__)[0])
+
+        browser.login().visit()
+        factoriesmenu.add('File')
+        with open(file_path, 'r') as file_:
+            browser.fill({'Title': 'My file',
+                          'Filename': 'myfile',
+                          'File': (file_.read(),
+                                   'test.pdf')
+                          }).save()
+
+        self.assertIn(browser.context.getId(), self.portal)
+
+        self.registry['ftw.file.filesettings.invalid_mimeteypes'] = [u'application/pdf', ]
+        transaction.commit()
+        browser.login().visit()
+        with open(file_path, 'r') as file_:
+            factoriesmenu.add('File')
+            browser.fill({'Title': 'My file',
+                          'Filename': 'myfile',
+                          'File': (file_.read(),
+                                   'test.pdf')
+                          }).save()
+        self.assertEquals(
+            u'Invalid mime type: application/pdf is not allowed',
+            browser.css('.fieldErrorBox .error').first.text
+        )


### PR DESCRIPTION
<img width="1117" alt="Screenshot 2020-11-05 at 08 55 22" src="https://user-images.githubusercontent.com/437933/98213450-63a69c80-1f45-11eb-9290-c097d3a2038b.png">

The message, that the file is already uploaded comes from plone.formwidget.namefile, since plone now temporary stores files uploaded via html form for you, so it can be used after a validation error and does not have to be chosen again. 