### PR TITLE
Pin certifi for plone 4.3 tests.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,3 +8,5 @@ package-name = ftw.file
 [versions]
 # node > 1a has breaking changes
 node = 0.9.28
+# newer versions of certify are python3 only
+certifi = < 2021.10.08


### PR DESCRIPTION
Nightlies have been failing for some time. certify has dropped support for python 2 in version [2020.04.05.2](https://github.com/certifi/python-certifi/releases/tag/2020.04.05.2), but definitely broken the package for python 3 when introducing type annotations (https://github.com/certifi/python-certifi/commit/5f09ea84b97202a41430fed5bb3cbd489d04c18e).